### PR TITLE
feat: T02 共通型定義

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,9 @@ export default tseslint.config(
       'react/react-in-jsx-scope': 'off',
       // ドメイン層で any を使わないよう警告
       '@typescript-eslint/no-explicit-any': 'error',
+      // ok/err 等のエクスポート名がローカル変数に意図せず上書きされるのを防ぐ
+      'no-shadow': 'off',
+      '@typescript-eslint/no-shadow': 'error',
     },
     settings: {
       react: { version: 'detect' },

--- a/src/shared/types/Result.ts
+++ b/src/shared/types/Result.ts
@@ -1,0 +1,6 @@
+export type Result<T, E = string> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: E }
+
+export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value })
+export const err = <E>(error: E): Result<never, E> => ({ ok: false, error })

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,16 @@
+// --- Brand types ---
+// Nominal typing for entity IDs to prevent accidental mixing of string IDs.
+// Usage: `const id = 'strike' as CardId`
+
+export type CardId = string & { readonly _brand: 'CardId' }
+export type RelicId = string & { readonly _brand: 'RelicId' }
+export type PotionId = string & { readonly _brand: 'PotionId' }
+export type EnemyId = string & { readonly _brand: 'EnemyId' }
+export type NodeId = string & { readonly _brand: 'NodeId' }
+export type EffectId = string & { readonly _brand: 'EffectId' }
+// StatusEffectId: Strength, Vulnerable, Weak, Poison 等の持続型状態効果（T12）
+export type StatusEffectId = string & { readonly _brand: 'StatusEffectId' }
+
+// --- Re-exports ---
+export type { Result } from './Result'
+export { ok, err } from './Result'


### PR DESCRIPTION
## 概要

全層で共通して使用する型定義を実装しました。

## 変更内容

- `src/shared/types/index.ts` — ブランド型ID（CardId, RelicId, PotionId, EnemyId, NodeId, EffectId, StatusEffectId）
- `src/shared/types/Result.ts` — `Result<T, E>` 型と `ok` / `err` ヘルパー
- `eslint.config.js` — `@typescript-eslint/no-shadow` ルール追加

## 設計メモ

- `EffectId`（カードプレイ効果）と `StatusEffectId`（持続型状態効果）を分離（アーキテクチャレビューにて指摘）
- `Result.match` / コンストラクタ関数はYAGNI判断によりスキップ（T43 / T30 で対応）
- T18 MapNode の `connections` は `readonly NodeId[]` にすべき旨をissueにコメント済み

Closes #2