### PR TITLE
feat: T07 HP値オブジェクト

### DIFF
--- a/src/domain/value-objects/Health.ts
+++ b/src/domain/value-objects/Health.ts
@@ -1,0 +1,32 @@
+import { type Result, ok, err } from '../../shared/types'
+
+export class Health {
+  readonly current: number
+  readonly max: number
+
+  private constructor(current: number, max: number) {
+    this.current = current
+    this.max = max
+  }
+
+  static create(current: number, max: number): Result<Health> {
+    if (max <= 0) return err('max must be greater than 0')
+    if (current < 0) return err('current must be 0 or greater')
+    if (current > max) return err('current must not exceed max')
+    return ok(new Health(current, max))
+  }
+
+  takeDamage(amount: number): Health {
+    const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0
+    return new Health(Math.max(0, this.current - safeAmount), this.max)
+  }
+
+  heal(amount: number): Health {
+    const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0
+    return new Health(Math.min(this.max, this.current + safeAmount), this.max)
+  }
+
+  isDead(): boolean {
+    return this.current === 0
+  }
+}

--- a/tests/domain/value-objects/Health.test.ts
+++ b/tests/domain/value-objects/Health.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import { Health } from '../../../src/domain/value-objects/Health'
+
+describe('Health.create', () => {
+  it('正常な値でHealthを生成できる', () => {
+    const result = Health.create(50, 100)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.current).toBe(50)
+      expect(result.value.max).toBe(100)
+    }
+  })
+
+  it('current === max でも生成できる', () => {
+    const result = Health.create(100, 100)
+    expect(result.ok).toBe(true)
+  })
+
+  it('current === 0 でも生成できる（死亡状態）', () => {
+    const result = Health.create(0, 100)
+    expect(result.ok).toBe(true)
+  })
+
+  it('current が負の値の場合はエラーメッセージを返す', () => {
+    const result = Health.create(-1, 100)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('current must be 0 or greater')
+  })
+
+  it('max が 0 の場合はエラーメッセージを返す', () => {
+    const result = Health.create(0, 0)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('max must be greater than 0')
+  })
+
+  it('max が負の値の場合はエラーメッセージを返す', () => {
+    const result = Health.create(0, -10)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('max must be greater than 0')
+  })
+
+  it('current が max を超える場合はエラーメッセージを返す', () => {
+    const result = Health.create(101, 100)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('current must not exceed max')
+  })
+})
+
+describe('Health#takeDamage', () => {
+  it('ダメージを受けて current が減る', () => {
+    const health = Health.create(100, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(30)
+    expect(damaged.current).toBe(70)
+    expect(damaged.max).toBe(100)
+  })
+
+  it('ダメージが current を超えても 0 未満にならない', () => {
+    const health = Health.create(10, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(50)
+    expect(damaged.current).toBe(0)
+  })
+
+  it('ダメージ 0 は変化しない', () => {
+    const health = Health.create(80, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(0)
+    expect(damaged.current).toBe(80)
+  })
+
+  it('死亡状態のエンティティにダメージを与えても current は 0 のまま', () => {
+    const health = Health.create(0, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(50)
+    expect(damaged.current).toBe(0)
+  })
+
+  it('負のダメージは 0 として扱う', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(-10)
+    expect(damaged.current).toBe(50)
+  })
+
+  it('NaN のダメージは 0 として扱う', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(NaN)
+    expect(damaged.current).toBe(50)
+  })
+
+  it('Infinity のダメージは 0 として扱う', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const damaged = health.value.takeDamage(Infinity)
+    expect(damaged.current).toBe(50)
+  })
+
+  it('元のオブジェクトは変更されない（イミュータブル）', () => {
+    const health = Health.create(100, 100)
+    if (!health.ok) throw new Error('setup failed')
+    health.value.takeDamage(50)
+    expect(health.value.current).toBe(100)
+  })
+})
+
+describe('Health#heal', () => {
+  it('回復して current が増える', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(20)
+    expect(healed.current).toBe(70)
+    expect(healed.max).toBe(100)
+  })
+
+  it('回復量が max を超えても max を超えない', () => {
+    const health = Health.create(90, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(50)
+    expect(healed.current).toBe(100)
+  })
+
+  it('回復 0 は変化しない', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(0)
+    expect(healed.current).toBe(50)
+  })
+
+  it('死亡状態から回復できる', () => {
+    const health = Health.create(0, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(30)
+    expect(healed.current).toBe(30)
+    expect(healed.isDead()).toBe(false)
+  })
+
+  it('負の回復量は 0 として扱う', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(-10)
+    expect(healed.current).toBe(50)
+  })
+
+  it('NaN の回復量は 0 として扱う', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    const healed = health.value.heal(NaN)
+    expect(healed.current).toBe(50)
+  })
+
+  it('元のオブジェクトは変更されない（イミュータブル）', () => {
+    const health = Health.create(50, 100)
+    if (!health.ok) throw new Error('setup failed')
+    health.value.heal(50)
+    expect(health.value.current).toBe(50)
+  })
+})
+
+describe('Health#isDead', () => {
+  it('current === 0 のとき true', () => {
+    const health = Health.create(0, 100)
+    if (!health.ok) throw new Error('setup failed')
+    expect(health.value.isDead()).toBe(true)
+  })
+
+  it('current > 0 のとき false', () => {
+    const health = Health.create(1, 100)
+    if (!health.ok) throw new Error('setup failed')
+    expect(health.value.isDead()).toBe(false)
+  })
+
+  it('current === max（フル体力）のとき false', () => {
+    const health = Health.create(100, 100)
+    if (!health.ok) throw new Error('setup failed')
+    expect(health.value.isDead()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- `Health` value objectを実装（`src/domain/value-objects/Health.ts`）
- `Result<Health>` を返すファクトリメソッド（`create`）でバリデーションを集約
- `takeDamage` / `heal` は負値・NaN・Infinityを0扱いにしイミュータブル性を保証
- Vitestで25テストケース（境界値・エラーメッセージ検証・イミュータブル検証含む）

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm run test:run` 25テスト全通過
- [x] `typescript-reviewer` レビュー実施・HIGH/MEDIUM指摘を修正済み
- [x] `code-reviewer` レビュー実施済み

Closes #7