### PR TITLE
feat: T11 シード値オブジェクト

### DIFF
--- a/src/domain/value-objects/Seed.ts
+++ b/src/domain/value-objects/Seed.ts
@@ -6,18 +6,16 @@ export class Seed {
   }
 
   static create(value: string): Seed {
-    if (value.length === 0) throw new Error('Seed value must not be empty')
+    if (value.trim().length === 0) throw new Error('Seed value must not be empty or whitespace')
     return new Seed(value)
   }
 
   static generate(): Seed {
-    const timestamp = Date.now().toString(36)
-    const random = Math.random().toString(36).slice(2)
-    return new Seed(`${timestamp}-${random}`)
+    return new Seed(crypto.randomUUID())
   }
 
   static fromString(s: string): Seed {
-    if (s.length === 0) throw new Error('Seed value must not be empty')
+    if (s.trim().length === 0) throw new Error('Seed value must not be empty or whitespace')
     return new Seed(s)
   }
 }

--- a/src/domain/value-objects/Seed.ts
+++ b/src/domain/value-objects/Seed.ts
@@ -1,0 +1,23 @@
+export class Seed {
+  readonly value: string
+
+  private constructor(value: string) {
+    this.value = value
+  }
+
+  static create(value: string): Seed {
+    if (value.length === 0) throw new Error('Seed value must not be empty')
+    return new Seed(value)
+  }
+
+  static generate(): Seed {
+    const timestamp = Date.now().toString(36)
+    const random = Math.random().toString(36).slice(2)
+    return new Seed(`${timestamp}-${random}`)
+  }
+
+  static fromString(s: string): Seed {
+    if (s.length === 0) throw new Error('Seed value must not be empty')
+    return new Seed(s)
+  }
+}

--- a/src/domain/value-objects/Seed.ts
+++ b/src/domain/value-objects/Seed.ts
@@ -1,3 +1,5 @@
+import { type Result, ok, err } from '../../shared/types'
+
 export class Seed {
   readonly value: string
 
@@ -5,17 +7,17 @@ export class Seed {
     this.value = value
   }
 
-  static create(value: string): Seed {
-    if (value.trim().length === 0) throw new Error('Seed value must not be empty or whitespace')
-    return new Seed(value)
+  static create(value: string): Result<Seed> {
+    if (value.trim().length === 0) return err('Seed value must not be empty or whitespace')
+    return ok(new Seed(value))
   }
 
   static generate(): Seed {
     return new Seed(crypto.randomUUID())
   }
 
-  static fromString(s: string): Seed {
-    if (s.trim().length === 0) throw new Error('Seed value must not be empty or whitespace')
-    return new Seed(s)
+  static fromString(s: string): Result<Seed> {
+    if (s.trim().length === 0) return err('Seed value must not be empty or whitespace')
+    return ok(new Seed(s))
   }
 }

--- a/tests/domain/value-objects/Seed.test.ts
+++ b/tests/domain/value-objects/Seed.test.ts
@@ -3,21 +3,25 @@ import { Seed } from '../../../src/domain/value-objects/Seed'
 
 describe('Seed.create', () => {
   it('文字列からSeedを生成できる', () => {
-    const seed = Seed.create('abc123')
-    expect(seed.value).toBe('abc123')
+    const result = Seed.create('abc123')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.value).toBe('abc123')
   })
 
   it('数値文字列からSeedを生成できる', () => {
-    const seed = Seed.create('12345')
-    expect(seed.value).toBe('12345')
+    const result = Seed.create('12345')
+    expect(result.ok).toBe(true)
   })
 
-  it('空文字列の場合はエラーをスローする', () => {
-    expect(() => Seed.create('')).toThrow()
+  it('空文字列の場合はエラーを返す', () => {
+    const result = Seed.create('')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('Seed value must not be empty or whitespace')
   })
 
-  it('ホワイトスペースのみの場合はエラーをスローする', () => {
-    expect(() => Seed.create('   ')).toThrow()
+  it('ホワイトスペースのみの場合はエラーを返す', () => {
+    const result = Seed.create('   ')
+    expect(result.ok).toBe(false)
   })
 })
 
@@ -31,7 +35,6 @@ describe('Seed.generate', () => {
 
   it('UUID形式のSeedを生成する', () => {
     const seed = Seed.generate()
-    // crypto.randomUUID() は xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx 形式
     expect(seed.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
   })
 
@@ -43,22 +46,27 @@ describe('Seed.generate', () => {
 
 describe('Seed.fromString', () => {
   it('文字列からSeedを復元できる', () => {
-    const seed = Seed.fromString('my-run-seed')
-    expect(seed.value).toBe('my-run-seed')
+    const result = Seed.fromString('my-run-seed')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.value).toBe('my-run-seed')
   })
 
-  it('空文字列の場合はエラーをスローする', () => {
-    expect(() => Seed.fromString('')).toThrow()
+  it('空文字列の場合はエラーを返す', () => {
+    const result = Seed.fromString('')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('Seed value must not be empty or whitespace')
   })
 
-  it('ホワイトスペースのみの場合はエラーをスローする', () => {
-    expect(() => Seed.fromString('   ')).toThrow()
+  it('ホワイトスペースのみの場合はエラーを返す', () => {
+    const result = Seed.fromString('   ')
+    expect(result.ok).toBe(false)
   })
 })
 
 describe('Seed value immutability', () => {
   it('valueプロパティはreadonlyである', () => {
     const seed = Seed.create('test')
-    expect(seed.value).toBe('test')
+    if (!seed.ok) throw new Error('setup failed')
+    expect(seed.value.value).toBe('test')
   })
 })

--- a/tests/domain/value-objects/Seed.test.ts
+++ b/tests/domain/value-objects/Seed.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { Seed } from '../../../src/domain/value-objects/Seed'
+
+describe('Seed.create', () => {
+  it('文字列からSeedを生成できる', () => {
+    const seed = Seed.create('abc123')
+    expect(seed.value).toBe('abc123')
+  })
+
+  it('数値文字列からSeedを生成できる', () => {
+    const seed = Seed.create('12345')
+    expect(seed.value).toBe('12345')
+  })
+
+  it('空文字列の場合はエラーをスローする', () => {
+    expect(() => Seed.create('')).toThrow()
+  })
+})
+
+describe('Seed.generate', () => {
+  it('ランダムなSeedを生成できる', () => {
+    const seed = Seed.generate()
+    expect(seed.value).toBeTruthy()
+    expect(typeof seed.value).toBe('string')
+    expect(seed.value.length).toBeGreaterThan(0)
+  })
+
+  it('生成するたびに異なるSeedが生成される（高確率）', () => {
+    const seed1 = Seed.generate()
+    const seed2 = Seed.generate()
+    // 乱数なので稀に同じになる可能性があるが、通常は異なる
+    // 統計的に正しいことを確認（100回試行）
+    const values = new Set(Array.from({ length: 100 }, () => Seed.generate().value))
+    expect(values.size).toBeGreaterThan(50)
+  })
+})
+
+describe('Seed.fromString', () => {
+  it('文字列からSeedを復元できる', () => {
+    const seed = Seed.fromString('my-run-seed')
+    expect(seed.value).toBe('my-run-seed')
+  })
+
+  it('空文字列の場合はエラーをスローする', () => {
+    expect(() => Seed.fromString('')).toThrow()
+  })
+})
+
+describe('Seed value immutability', () => {
+  it('valueプロパティはreadonlyである', () => {
+    const seed = Seed.create('test')
+    expect(seed.value).toBe('test')
+    // TypeScript型レベルでreadonly保証
+  })
+})

--- a/tests/domain/value-objects/Seed.test.ts
+++ b/tests/domain/value-objects/Seed.test.ts
@@ -15,6 +15,10 @@ describe('Seed.create', () => {
   it('空文字列の場合はエラーをスローする', () => {
     expect(() => Seed.create('')).toThrow()
   })
+
+  it('ホワイトスペースのみの場合はエラーをスローする', () => {
+    expect(() => Seed.create('   ')).toThrow()
+  })
 })
 
 describe('Seed.generate', () => {
@@ -25,13 +29,15 @@ describe('Seed.generate', () => {
     expect(seed.value.length).toBeGreaterThan(0)
   })
 
-  it('生成するたびに異なるSeedが生成される（高確率）', () => {
-    const seed1 = Seed.generate()
-    const seed2 = Seed.generate()
-    // 乱数なので稀に同じになる可能性があるが、通常は異なる
-    // 統計的に正しいことを確認（100回試行）
+  it('UUID形式のSeedを生成する', () => {
+    const seed = Seed.generate()
+    // crypto.randomUUID() は xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx 形式
+    expect(seed.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+  })
+
+  it('生成するたびに異なるSeedが生成される', () => {
     const values = new Set(Array.from({ length: 100 }, () => Seed.generate().value))
-    expect(values.size).toBeGreaterThan(50)
+    expect(values.size).toBe(100)
   })
 })
 
@@ -44,12 +50,15 @@ describe('Seed.fromString', () => {
   it('空文字列の場合はエラーをスローする', () => {
     expect(() => Seed.fromString('')).toThrow()
   })
+
+  it('ホワイトスペースのみの場合はエラーをスローする', () => {
+    expect(() => Seed.fromString('   ')).toThrow()
+  })
 })
 
 describe('Seed value immutability', () => {
   it('valueプロパティはreadonlyである', () => {
     const seed = Seed.create('test')
     expect(seed.value).toBe('test')
-    // TypeScript型レベルでreadonly保証
   })
 })


### PR DESCRIPTION
## 概要
ローグライクの再現性を担保するための乱数シードを管理する値オブジェクトを実装した。

## 実装内容
- `Seed.create(value): Result<Seed>` — バリデーション付きファクトリ（空文字・ホワイトスペースチェック）
- `Seed.generate()` — `crypto.randomUUID()` によるランダムシード生成
- `Seed.fromString(s): Result<Seed>` — 文字列からシード復元

## レビュー対応
- `Math.random()` を `crypto.randomUUID()` に変更（衝突確率ゼロ・UUID形式）
- ホワイトスペースのみの文字列をエラーとして処理
- `create` / `fromString` を `Result<Seed>` 型に変更（Health.ts との設計統一）

## 完了条件チェック
- [x] 対象ファイルが実装されている
- [x] npm run typecheck が通る
- [x] npm run lint が通る
- [x] tests/ 以下にテストファイルが存在する（11テスト）
- [x] npm run test が通る
- [x] code-reviewer によるレビューを実施している
- [x] typescript-reviewer によるレビューを実施している

Closes #11