### PR TITLE
feat: T08 エネルギー値オブジェクト

### DIFF
--- a/src/domain/value-objects/Energy.ts
+++ b/src/domain/value-objects/Energy.ts
@@ -1,0 +1,29 @@
+export class Energy {
+  readonly current: number
+  readonly max: number
+
+  private constructor(current: number, max: number) {
+    this.current = current
+    this.max = max
+  }
+
+  static create(current: number, max: number): Energy {
+    if (max <= 0) throw new Error('max must be greater than 0')
+    if (current < 0) throw new Error('current must be 0 or greater')
+    if (current > max) throw new Error('current must not exceed max')
+    return new Energy(current, max)
+  }
+
+  spend(cost: number): Energy {
+    if (cost > this.current) throw new Error('Not enough energy')
+    return new Energy(this.current - cost, this.max)
+  }
+
+  refill(): Energy {
+    return new Energy(this.max, this.max)
+  }
+
+  canAfford(cost: number): boolean {
+    return cost <= this.current
+  }
+}

--- a/src/domain/value-objects/Energy.ts
+++ b/src/domain/value-objects/Energy.ts
@@ -8,6 +8,8 @@ export class Energy {
   }
 
   static create(current: number, max: number): Energy {
+    if (!Number.isFinite(current) || !Number.isFinite(max))
+      throw new Error('values must be finite numbers')
     if (max <= 0) throw new Error('max must be greater than 0')
     if (current < 0) throw new Error('current must be 0 or greater')
     if (current > max) throw new Error('current must not exceed max')
@@ -15,6 +17,8 @@ export class Energy {
   }
 
   spend(cost: number): Energy {
+    if (!Number.isFinite(cost) || cost < 0)
+      throw new Error('cost must be a non-negative finite number')
     if (cost > this.current) throw new Error('Not enough energy')
     return new Energy(this.current - cost, this.max)
   }
@@ -24,6 +28,7 @@ export class Energy {
   }
 
   canAfford(cost: number): boolean {
+    if (!Number.isFinite(cost) || cost < 0) return false
     return cost <= this.current
   }
 }

--- a/src/domain/value-objects/Energy.ts
+++ b/src/domain/value-objects/Energy.ts
@@ -1,3 +1,5 @@
+import { type Result, ok, err } from '../../shared/types'
+
 export class Energy {
   readonly current: number
   readonly max: number
@@ -7,20 +9,20 @@ export class Energy {
     this.max = max
   }
 
-  static create(current: number, max: number): Energy {
+  static create(current: number, max: number): Result<Energy> {
     if (!Number.isFinite(current) || !Number.isFinite(max))
-      throw new Error('values must be finite numbers')
-    if (max <= 0) throw new Error('max must be greater than 0')
-    if (current < 0) throw new Error('current must be 0 or greater')
-    if (current > max) throw new Error('current must not exceed max')
-    return new Energy(current, max)
+      return err('values must be finite numbers')
+    if (max <= 0) return err('max must be greater than 0')
+    if (current < 0) return err('current must be 0 or greater')
+    if (current > max) return err('current must not exceed max')
+    return ok(new Energy(current, max))
   }
 
-  spend(cost: number): Energy {
+  spend(cost: number): Result<Energy> {
     if (!Number.isFinite(cost) || cost < 0)
       throw new Error('cost must be a non-negative finite number')
-    if (cost > this.current) throw new Error('Not enough energy')
-    return new Energy(this.current - cost, this.max)
+    if (cost > this.current) return err('not enough energy')
+    return ok(new Energy(this.current - cost, this.max))
   }
 
   refill(): Energy {

--- a/tests/domain/value-objects/Energy.test.ts
+++ b/tests/domain/value-objects/Energy.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+
+describe('Energy.create', () => {
+  it('正常な値でEnergyを生成できる', () => {
+    const energy = Energy.create(3, 3)
+    expect(energy.current).toBe(3)
+    expect(energy.max).toBe(3)
+  })
+
+  it('current が max 未満でも生成できる', () => {
+    const energy = Energy.create(1, 3)
+    expect(energy.current).toBe(1)
+    expect(energy.max).toBe(3)
+  })
+
+  it('current === 0 でも生成できる', () => {
+    const energy = Energy.create(0, 3)
+    expect(energy.current).toBe(0)
+  })
+
+  it('current が負の値の場合はエラーをスローする', () => {
+    expect(() => Energy.create(-1, 3)).toThrow()
+  })
+
+  it('max が 0 以下の場合はエラーをスローする', () => {
+    expect(() => Energy.create(0, 0)).toThrow()
+  })
+
+  it('current が max を超える場合はエラーをスローする', () => {
+    expect(() => Energy.create(4, 3)).toThrow()
+  })
+})
+
+describe('Energy#spend', () => {
+  it('コストを消費してエネルギーが減る', () => {
+    const energy = Energy.create(3, 3)
+    const result = energy.spend(2)
+    expect(result.current).toBe(1)
+    expect(result.max).toBe(3)
+  })
+
+  it('ちょうど全消費できる', () => {
+    const energy = Energy.create(3, 3)
+    const result = energy.spend(3)
+    expect(result.current).toBe(0)
+  })
+
+  it('エネルギーが不足している場合はエラーをスローする', () => {
+    const energy = Energy.create(1, 3)
+    expect(() => energy.spend(2)).toThrow()
+  })
+
+  it('消費量 0 は変化しない', () => {
+    const energy = Energy.create(3, 3)
+    const result = energy.spend(0)
+    expect(result.current).toBe(3)
+  })
+
+  it('元のオブジェクトは変更されない（イミュータブル）', () => {
+    const energy = Energy.create(3, 3)
+    energy.spend(2)
+    expect(energy.current).toBe(3)
+  })
+})
+
+describe('Energy#refill', () => {
+  it('maxまでエネルギーが回復する', () => {
+    const energy = Energy.create(1, 3)
+    const result = energy.refill()
+    expect(result.current).toBe(3)
+    expect(result.max).toBe(3)
+  })
+
+  it('すでにmaxの場合は変化しない', () => {
+    const energy = Energy.create(3, 3)
+    const result = energy.refill()
+    expect(result.current).toBe(3)
+  })
+
+  it('元のオブジェクトは変更されない（イミュータブル）', () => {
+    const energy = Energy.create(1, 3)
+    energy.refill()
+    expect(energy.current).toBe(1)
+  })
+})
+
+describe('Energy#canAfford', () => {
+  it('コストがcurrent以下の場合はtrueを返す', () => {
+    const energy = Energy.create(3, 3)
+    expect(energy.canAfford(2)).toBe(true)
+  })
+
+  it('コストがcurrentと同じ場合はtrueを返す', () => {
+    const energy = Energy.create(3, 3)
+    expect(energy.canAfford(3)).toBe(true)
+  })
+
+  it('コストがcurrentを超える場合はfalseを返す', () => {
+    const energy = Energy.create(1, 3)
+    expect(energy.canAfford(2)).toBe(false)
+  })
+
+  it('コスト 0 は常にtrueを返す', () => {
+    const energy = Energy.create(0, 3)
+    expect(energy.canAfford(0)).toBe(true)
+  })
+})

--- a/tests/domain/value-objects/Energy.test.ts
+++ b/tests/domain/value-objects/Energy.test.ts
@@ -30,6 +30,16 @@ describe('Energy.create', () => {
   it('current が max を超える場合はエラーをスローする', () => {
     expect(() => Energy.create(4, 3)).toThrow()
   })
+
+  it('NaN の場合はエラーをスローする', () => {
+    expect(() => Energy.create(NaN, 3)).toThrow()
+    expect(() => Energy.create(3, NaN)).toThrow()
+  })
+
+  it('Infinity の場合はエラーをスローする', () => {
+    expect(() => Energy.create(Infinity, 3)).toThrow()
+    expect(() => Energy.create(3, Infinity)).toThrow()
+  })
 })
 
 describe('Energy#spend', () => {
@@ -55,6 +65,16 @@ describe('Energy#spend', () => {
     const energy = Energy.create(3, 3)
     const result = energy.spend(0)
     expect(result.current).toBe(3)
+  })
+
+  it('負のコストの場合はエラーをスローする', () => {
+    const energy = Energy.create(3, 3)
+    expect(() => energy.spend(-1)).toThrow()
+  })
+
+  it('NaN のコストの場合はエラーをスローする', () => {
+    const energy = Energy.create(3, 3)
+    expect(() => energy.spend(NaN)).toThrow()
   })
 
   it('元のオブジェクトは変更されない（イミュータブル）', () => {
@@ -104,5 +124,15 @@ describe('Energy#canAfford', () => {
   it('コスト 0 は常にtrueを返す', () => {
     const energy = Energy.create(0, 3)
     expect(energy.canAfford(0)).toBe(true)
+  })
+
+  it('負のコストの場合はfalseを返す', () => {
+    const energy = Energy.create(3, 3)
+    expect(energy.canAfford(-1)).toBe(false)
+  })
+
+  it('NaN のコストの場合はfalseを返す', () => {
+    const energy = Energy.create(3, 3)
+    expect(energy.canAfford(NaN)).toBe(false)
   })
 })

--- a/tests/domain/value-objects/Energy.test.ts
+++ b/tests/domain/value-objects/Energy.test.ts
@@ -3,136 +3,171 @@ import { Energy } from '../../../src/domain/value-objects/Energy'
 
 describe('Energy.create', () => {
   it('正常な値でEnergyを生成できる', () => {
-    const energy = Energy.create(3, 3)
-    expect(energy.current).toBe(3)
-    expect(energy.max).toBe(3)
+    const result = Energy.create(3, 3)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.current).toBe(3)
+      expect(result.value.max).toBe(3)
+    }
   })
 
   it('current が max 未満でも生成できる', () => {
-    const energy = Energy.create(1, 3)
-    expect(energy.current).toBe(1)
-    expect(energy.max).toBe(3)
+    const result = Energy.create(1, 3)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.current).toBe(1)
+      expect(result.value.max).toBe(3)
+    }
   })
 
   it('current === 0 でも生成できる', () => {
-    const energy = Energy.create(0, 3)
-    expect(energy.current).toBe(0)
+    const result = Energy.create(0, 3)
+    expect(result.ok).toBe(true)
   })
 
-  it('current が負の値の場合はエラーをスローする', () => {
-    expect(() => Energy.create(-1, 3)).toThrow()
+  it('current が負の値の場合はエラーを返す', () => {
+    const result = Energy.create(-1, 3)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('current must be 0 or greater')
   })
 
-  it('max が 0 以下の場合はエラーをスローする', () => {
-    expect(() => Energy.create(0, 0)).toThrow()
+  it('max が 0 以下の場合はエラーを返す', () => {
+    const result = Energy.create(0, 0)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('max must be greater than 0')
   })
 
-  it('current が max を超える場合はエラーをスローする', () => {
-    expect(() => Energy.create(4, 3)).toThrow()
+  it('current が max を超える場合はエラーを返す', () => {
+    const result = Energy.create(4, 3)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('current must not exceed max')
   })
 
-  it('NaN の場合はエラーをスローする', () => {
-    expect(() => Energy.create(NaN, 3)).toThrow()
-    expect(() => Energy.create(3, NaN)).toThrow()
+  it('NaN の場合はエラーを返す', () => {
+    const result = Energy.create(NaN, 3)
+    expect(result.ok).toBe(false)
   })
 
-  it('Infinity の場合はエラーをスローする', () => {
-    expect(() => Energy.create(Infinity, 3)).toThrow()
-    expect(() => Energy.create(3, Infinity)).toThrow()
+  it('Infinity の場合はエラーを返す', () => {
+    const result = Energy.create(Infinity, 3)
+    expect(result.ok).toBe(false)
   })
 })
 
 describe('Energy#spend', () => {
   it('コストを消費してエネルギーが減る', () => {
     const energy = Energy.create(3, 3)
-    const result = energy.spend(2)
-    expect(result.current).toBe(1)
-    expect(result.max).toBe(3)
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.spend(2)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.current).toBe(1)
+      expect(result.value.max).toBe(3)
+    }
   })
 
   it('ちょうど全消費できる', () => {
     const energy = Energy.create(3, 3)
-    const result = energy.spend(3)
-    expect(result.current).toBe(0)
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.spend(3)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.current).toBe(0)
   })
 
-  it('エネルギーが不足している場合はエラーをスローする', () => {
+  it('エネルギーが不足している場合はエラーを返す', () => {
     const energy = Energy.create(1, 3)
-    expect(() => energy.spend(2)).toThrow()
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.spend(2)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('not enough energy')
   })
 
   it('消費量 0 は変化しない', () => {
     const energy = Energy.create(3, 3)
-    const result = energy.spend(0)
-    expect(result.current).toBe(3)
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.spend(0)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value.current).toBe(3)
   })
 
-  it('負のコストの場合はエラーをスローする', () => {
+  it('負のコストの場合はエラーをスローする（プログラマーのバグ）', () => {
     const energy = Energy.create(3, 3)
-    expect(() => energy.spend(-1)).toThrow()
+    if (!energy.ok) throw new Error('setup failed')
+    expect(() => energy.value.spend(-1)).toThrow()
   })
 
-  it('NaN のコストの場合はエラーをスローする', () => {
+  it('NaN のコストの場合はエラーをスローする（プログラマーのバグ）', () => {
     const energy = Energy.create(3, 3)
-    expect(() => energy.spend(NaN)).toThrow()
+    if (!energy.ok) throw new Error('setup failed')
+    expect(() => energy.value.spend(NaN)).toThrow()
   })
 
   it('元のオブジェクトは変更されない（イミュータブル）', () => {
     const energy = Energy.create(3, 3)
-    energy.spend(2)
-    expect(energy.current).toBe(3)
+    if (!energy.ok) throw new Error('setup failed')
+    energy.value.spend(2)
+    expect(energy.value.current).toBe(3)
   })
 })
 
 describe('Energy#refill', () => {
   it('maxまでエネルギーが回復する', () => {
     const energy = Energy.create(1, 3)
-    const result = energy.refill()
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.refill()
     expect(result.current).toBe(3)
     expect(result.max).toBe(3)
   })
 
   it('すでにmaxの場合は変化しない', () => {
     const energy = Energy.create(3, 3)
-    const result = energy.refill()
+    if (!energy.ok) throw new Error('setup failed')
+    const result = energy.value.refill()
     expect(result.current).toBe(3)
   })
 
   it('元のオブジェクトは変更されない（イミュータブル）', () => {
     const energy = Energy.create(1, 3)
-    energy.refill()
-    expect(energy.current).toBe(1)
+    if (!energy.ok) throw new Error('setup failed')
+    energy.value.refill()
+    expect(energy.value.current).toBe(1)
   })
 })
 
 describe('Energy#canAfford', () => {
   it('コストがcurrent以下の場合はtrueを返す', () => {
     const energy = Energy.create(3, 3)
-    expect(energy.canAfford(2)).toBe(true)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(2)).toBe(true)
   })
 
   it('コストがcurrentと同じ場合はtrueを返す', () => {
     const energy = Energy.create(3, 3)
-    expect(energy.canAfford(3)).toBe(true)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(3)).toBe(true)
   })
 
   it('コストがcurrentを超える場合はfalseを返す', () => {
     const energy = Energy.create(1, 3)
-    expect(energy.canAfford(2)).toBe(false)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(2)).toBe(false)
   })
 
   it('コスト 0 は常にtrueを返す', () => {
     const energy = Energy.create(0, 3)
-    expect(energy.canAfford(0)).toBe(true)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(0)).toBe(true)
   })
 
   it('負のコストの場合はfalseを返す', () => {
     const energy = Energy.create(3, 3)
-    expect(energy.canAfford(-1)).toBe(false)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(-1)).toBe(false)
   })
 
   it('NaN のコストの場合はfalseを返す', () => {
     const energy = Energy.create(3, 3)
-    expect(energy.canAfford(NaN)).toBe(false)
+    if (!energy.ok) throw new Error('setup failed')
+    expect(energy.value.canAfford(NaN)).toBe(false)
   })
 })


### PR DESCRIPTION
## 概要
ターン中のエネルギーを管理する値オブジェクトを実装した。

## 実装内容
- `Energy.create(current, max): Result<Energy>` — バリデーション付きファクトリ（NaN/Infinity/負値/超過チェック）
- `spend(cost): Result<Energy>` — エネルギー消費（エネルギー不足はResult.err、負値・NaNはthrow）
- `refill()` — ターン開始時にmax回復
- `canAfford(cost)` — 支払い可否チェック（負値・NaNはfalse）

## レビュー対応
- `spend(-1)` でエネルギーが増加するバグを修正
- `canAfford(-1)` が常にtrueを返すバグを修正
- NaN/Infinity入力ガードを全メソッドに追加
- `Energy.create` / `Energy.spend` を `Result<Energy>` 型に変更（Health.ts との設計統一）

## 完了条件チェック
- [x] 対象ファイルが実装されている
- [x] npm run typecheck が通る
- [x] npm run lint が通る
- [x] tests/ 以下にテストファイルが存在する（24テスト）
- [x] npm run test が通る
- [x] code-reviewer によるレビューを実施している
- [x] typescript-reviewer によるレビューを実施している

Closes #8