### PR TITLE
ci: Node.js 24対応のアクションバージョンをピン留め

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,10 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: 24
           cache: 'npm'


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` → `actions/checkout@v4.2.2` にピン留め
- `actions/setup-node@v4` → `actions/setup-node@v4.4.0` にピン留め
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workaroundを削除（node-version: 24 + ピン留みアクションで不要になったため）

## Background
GitHub Actions で「Node.js 20 is deprecated」警告が出ていた。アクションのバージョンをv4の最新パッチに固定することで正式なNode.js 24ランタイムに移行し、警告を解消する。

## Test plan
- [ ] CI（typecheck / lint / test:run）がすべてグリーンになることを確認