### PR TITLE
feat: T13 カードエンティティ

### DIFF
--- a/src/domain/entities/Card.ts
+++ b/src/domain/entities/Card.ts
@@ -1,0 +1,24 @@
+import { type CardId, type EffectDef } from '../../shared/types'
+import { type CardType } from '../enums/CardType'
+import { type Rarity } from '../enums/Rarity'
+import { type TargetType } from '../enums/TargetType'
+
+/**
+ * カードエンティティ
+ *
+ * カードの静的定義（マスターデータとして持つべき情報）。
+ * プレイ中の状態（手札・デッキ内の位置等）は含まない。
+ *
+ * 参照可能な層: domain/enums, shared/types のみ
+ */
+export interface Card {
+  readonly id: CardId
+  readonly name: string
+  readonly description: string
+  readonly cost: number
+  readonly type: CardType
+  readonly rarity: Rarity
+  readonly targetType: TargetType
+  readonly effects: readonly EffectDef[]
+  readonly upgraded: boolean
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -11,6 +11,15 @@ export type EffectId = string & { readonly _brand: 'EffectId' }
 // StatusEffectId: Strength, Vulnerable, Weak, Poison 等の持続型状態効果（T12）
 export type StatusEffectId = string & { readonly _brand: 'StatusEffectId' }
 
+// --- Effect definition ---
+// Data structure representing a card effect as stored in JSON/Card entity.
+// Consumed by EffectFactory (application layer) to build executable Effect objects.
+export type EffectDef = {
+  readonly type: string
+  readonly value: number
+  readonly target?: string
+}
+
 // --- Re-exports ---
 export type { Result } from './Result'
 export { ok, err } from './Result'


### PR DESCRIPTION
## Summary
- `src/shared/types/index.ts` に `EffectDef` 型を追加（Card と EffectFactory の両層から参照できる shared な定義）
- `src/domain/entities/Card.ts` を新規作成（id/name/description/cost/type/rarity/targetType/effects/upgraded の静的定義）
- 依存は `shared/types` と `domain/enums` のみでレイヤー規則に準拠

Closes #13