### PR TITLE
feat: T19 プレイヤーエンティティ

### DIFF
--- a/src/domain/entities/Player.ts
+++ b/src/domain/entities/Player.ts
@@ -1,0 +1,32 @@
+import { type Energy } from '../value-objects/Energy'
+import { type Gold } from '../value-objects/Gold'
+import { type Card } from './Card'
+import { type Character } from './Character'
+import { type Potion } from './Potion'
+import { type Relic } from './Relic'
+
+/**
+ * プレイヤーエンティティ
+ *
+ * ラン中のプレイヤー全状態を保持するエンティティ。
+ * Character インターフェースを実装し、キャラクタークラスの識別子（id/name）と
+ * デッキ・手札・捨て札・排除札・レリック・ポーション・ゴールドを持つ。
+ *
+ * - powers プロパティは Combatant 経由で保持（Combat には持たせない設計）
+ * - potions の null は空きスロットを表す
+ * - potions.length は必ず maxPotionSlots と等しくなるよう Factory 層で保証すること
+ * - id は キャラクタークラス識別子（例: 'ironclad'）として使用する
+ *
+ * 参照可能な層: domain/entities, domain/value-objects のみ
+ */
+export interface Player extends Character {
+  readonly energy: Energy
+  readonly gold: Gold
+  readonly deck: readonly Card[]
+  readonly hand: readonly Card[]
+  readonly discardPile: readonly Card[]
+  readonly exhaustPile: readonly Card[]
+  readonly relics: readonly Relic[]
+  readonly maxPotionSlots: number
+  readonly potions: readonly (Potion | null)[]
+}

--- a/src/domain/entities/Potion.ts
+++ b/src/domain/entities/Potion.ts
@@ -1,0 +1,19 @@
+import { type PotionId } from '../../shared/types'
+import { type Rarity } from '../enums/Rarity'
+import { type TargetType } from '../enums/TargetType'
+
+/**
+ * ポーションエンティティ
+ *
+ * ポーションの静的定義（マスターデータとして持つべき情報）。
+ * 使用時の効果はアプリケーション層で処理する。
+ *
+ * 参照可能な層: domain/enums, shared/types のみ
+ */
+export interface Potion {
+  readonly id: PotionId
+  readonly name: string
+  readonly description: string
+  readonly rarity: Rarity
+  readonly targetType: TargetType
+}

--- a/src/domain/entities/Relic.ts
+++ b/src/domain/entities/Relic.ts
@@ -1,0 +1,69 @@
+import { type EnemyId, type RelicId } from '../../shared/types'
+import { type Rarity } from '../enums/Rarity'
+import { type Card } from './Card'
+
+/**
+ * ゲームイベント型
+ *
+ * レリックがリアクションするゲーム内イベントの種別。
+ * on_card_played はプレイされたカード情報を含む。
+ * on_enemy_killed は倒した敵の識別子を含む（特定種族対応レリック向け）。
+ *
+ * ⚠️ 現在は戦闘イベントのみ定義。コンバット外のイベント（on_rest_site 等）は
+ * RestSiteActionUseCase（T49）・SelectRewardUseCase（T47）実装時に追加すること。
+ * 詳細は各 Issue のコメントを参照。
+ */
+export type GameEvent =
+  | { type: 'on_combat_start' }
+  | { type: 'on_turn_start' }
+  | { type: 'on_turn_end' }
+  | { type: 'on_card_played'; card: Card }
+  | { type: 'on_combat_end'; victory: boolean }
+  | { type: 'on_enemy_killed'; enemyId: EnemyId }
+  | { type: 'on_hp_lost'; amount: number }
+
+/**
+ * レリックが要求する最小状態型
+ *
+ * Combat との循環依存（Combat → Player → Relic → Combat）を回避するため、
+ * onTrigger と notifyRelics が共有するジェネリック型変数の境界として定義する。
+ * 実際には Combat 型がこの構造を満たす。
+ */
+export type StateWithPlayer = {
+  readonly player: { readonly relics: readonly Relic[] }
+}
+
+/**
+ * レリックエンティティ（Observer パターン）
+ *
+ * 各レリックは自分がリアクションするイベント種別を triggers として宣言し、
+ * onTrigger で状態変換を返す純粋関数として実装する。
+ *
+ * onTrigger はジェネリック型を使用することで Combat.ts との循環依存を回避する。
+ * （Combat → Player → Relic → Combat の循環を防ぐ）
+ *
+ * 参照可能な層: domain/enums, domain/entities のみ
+ */
+export interface Relic {
+  readonly id: RelicId
+  readonly name: string
+  readonly description: string
+  readonly rarity: Rarity
+  readonly triggers: readonly GameEvent['type'][]
+  onTrigger<S extends StateWithPlayer>(event: GameEvent, state: S): S
+}
+
+/**
+ * レリックトリガーシステム
+ *
+ * イベント発生時に全レリックへ通知し、状態変換を順次適用する。
+ * StateWithPlayer 境界により Combat に依存せず、任意の戦闘状態型で動作する。
+ */
+export function notifyRelics<S extends StateWithPlayer>(event: GameEvent, state: S): S {
+  return state.player.relics.reduce((s, relic) => {
+    if (relic.triggers.includes(event.type)) {
+      return relic.onTrigger(event, s)
+    }
+    return s
+  }, state)
+}


### PR DESCRIPTION
Closes #19
Closes #14
Closes #15

## 概要

T19（プレイヤーエンティティ）の実装。依存する T14（レリック）・T15（ポーション）も合わせて実装。

## 実装内容

### Potion.ts（T15）
- `id` / `name` / `description` / `rarity` / `targetType` を持つ静的定義

### Relic.ts（T14）
- `GameEvent` 型（戦闘イベント union）を定義
- `StateWithPlayer` 型で Combat との循環依存を回避
- Observer パターンの `Relic` インターフェース
- `notifyRelics` 関数（純粋関数、任意の状態型に対応）
- `on_enemy_killed` に `enemyId: EnemyId` を追加（将来の破壊的変更防止）

### Player.ts（T19）
- `Character` インターフェースを実装（`id`/`name` によるキャラクタークラス識別）
- `deck` / `hand` / `discardPile` / `exhaustPile` / `relics` / `potions` / `energy` / `gold` を保持
- `maxPotionSlots` を追加しスロット数の不変条件を明示

## 設計判断（コードレビュー対応）

| 指摘 | 対応 |
|---|---|
| `Relic.onTrigger` 型制約不一致 | `StateWithPlayer` 境界を定義し `onTrigger` / `notifyRelics` で共有 |
| `on_enemy_killed` に敵情報なし | `enemyId: EnemyId` を追加 |
| `Player extends Combatant`（id なし） | `extends Character` に変更 |
| `maxPotionSlots` なし | プロパティとして明示追加 |
| `GameEvent` union の不完全性 | コンバット外イベントは T49・T47 実装時に追加（各 Issue にコメント済み） |

## テスト

Issue ラベルが `test:optional` のため省略。`notifyRelics` の単体テストは T20（Combat エンティティ）実装時に追加予定。

## チェックリスト

- [x] `npm run typecheck` が通る
- [x] `npm run lint` が通る
- [x] code-reviewer によるレビュー実施済み
- [x] typescript-reviewer によるレビュー実施済み