### PR TITLE
feat: T30 T31 Zodスキーマ定義・Ironcladカードデータ

### DIFF
--- a/src/infrastructure/data/cards/ironclad.json
+++ b/src/infrastructure/data/cards/ironclad.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "strike_r",
+    "name": "Strike",
+    "description": "Deal 6 damage.",
+    "cost": 1,
+    "card_type": "Attack",
+    "rarity": "Common",
+    "target_type": "Single",
+    "effects": [
+      { "type": "damage", "value": 6, "target": "single_enemy" }
+    ],
+    "upgraded": false
+  },
+  {
+    "id": "defend_r",
+    "name": "Defend",
+    "description": "Gain 5 Block.",
+    "cost": 1,
+    "card_type": "Skill",
+    "rarity": "Common",
+    "target_type": "Self",
+    "effects": [
+      { "type": "block", "value": 5, "target": "self" }
+    ],
+    "upgraded": false
+  },
+  {
+    "id": "bash",
+    "name": "Bash",
+    "description": "Deal 8 damage. Apply 2 Vulnerable.",
+    "cost": 2,
+    "card_type": "Attack",
+    "rarity": "Common",
+    "target_type": "Single",
+    "effects": [
+      { "type": "damage", "value": 8, "target": "single_enemy" },
+      { "type": "vulnerable", "value": 2, "target": "single_enemy" }
+    ],
+    "upgraded": false
+  }
+]

--- a/src/infrastructure/data/schemas.ts
+++ b/src/infrastructure/data/schemas.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+import { CardType } from '../../domain/enums/CardType'
+import { Rarity } from '../../domain/enums/Rarity'
+import { TargetType } from '../../domain/enums/TargetType'
+
+/**
+ * エフェクト定義スキーマ
+ *
+ * カード効果のJSONraw形状。EffectDefと対応するが、ドメイン型には依存しない。
+ * export することでリポジトリ層から個別バリデーションに使用できる。
+ */
+export const EffectDefSchema = z.object({
+  type: z.string().min(1),
+  value: z.number(),
+  target: z.string().optional(),
+})
+
+export type EffectDefRaw = z.infer<typeof EffectDefSchema>
+
+/**
+ * カードJSONのraw形状スキーマ
+ *
+ * JSONファイルのバリデーションのみを目的とする。
+ * ドメインEntityへの変換は各リポジトリ実装（T33等）の責務。
+ * フィールド名はsnake_case（JSONのraw形状）。ドメイン型のcamelCaseへの
+ * 変換はリポジトリのマッパー関数で行う。
+ *
+ * z.nativeEnum を使用することで、列挙型に新しい値が追加された際に
+ * 自動的にスキーマも追従し、列挙値のドリフトを防ぐ。
+ */
+export const CardSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  // コスト上限は設けない（X コスト等で大きな値になる可能性がある）
+  cost: z.number().int().min(0),
+  card_type: z.nativeEnum(CardType),
+  rarity: z.nativeEnum(Rarity),
+  target_type: z.nativeEnum(TargetType),
+  effects: z.array(EffectDefSchema),
+  upgraded: z.boolean(),
+})
+
+export type CardRaw = z.infer<typeof CardSchema>
+
+/**
+ * 敵JSONのraw形状スキーマ
+ *
+ * 敵マスターデータのJSONraw形状。
+ * 現在は最小限のフィールドのみ定義（壊れ検知の目的に限定）。
+ * 敵のアクション・インテント等は敵リポジトリ実装時に追加する。
+ */
+export const EnemySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  max_hp: z.number().int().positive(),
+})
+
+export type EnemyRaw = z.infer<typeof EnemySchema>
+
+/**
+ * レリックJSONのraw形状スキーマ
+ *
+ * レリックマスターデータのJSONraw形状。
+ */
+export const RelicSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  rarity: z.nativeEnum(Rarity),
+})
+
+export type RelicRaw = z.infer<typeof RelicSchema>
+
+/**
+ * ポーションJSONのraw形状スキーマ
+ *
+ * ポーションマスターデータのJSONraw形状。
+ * フィールド名はsnake_case（JSONのraw形状）。ドメイン型のcamelCaseへの
+ * 変換はリポジトリのマッパー関数で行う。
+ */
+export const PotionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  rarity: z.nativeEnum(Rarity),
+  target_type: z.nativeEnum(TargetType),
+})
+
+export type PotionRaw = z.infer<typeof PotionSchema>


### PR DESCRIPTION
## Summary
- T30: `src/infrastructure/data/schemas.ts` にCardSchema/EnemySchema/RelicSchema/PotionSchemaをZodで定義
  - `z.nativeEnum()` で列挙型ドリフトを防止（T03/T04/T06との同期を自動化）
  - `EffectDefSchema` をエクスポートしリポジトリ層からも利用可能に
  - 各スキーマから `CardRaw` / `EnemyRaw` / `RelicRaw` / `PotionRaw` 型をエクスポート
- T31: `src/infrastructure/data/cards/ironclad.json` にStrike/Defend/BashのJSONデータを追加（CardSchemaに準拠）

## Test plan
- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] `CardSchema.parse()` でironclad.jsonの各カードがバリデーションを通ること（T33実装時に確認）

Closes #30
Closes #31