### PR TITLE
feat: T33 カードリポジトリ実装

### DIFF
--- a/src/domain/interfaces/ICardRepository.ts
+++ b/src/domain/interfaces/ICardRepository.ts
@@ -1,0 +1,14 @@
+import { type Card } from '../entities/Card'
+import { type Rarity } from '../enums/Rarity'
+
+/**
+ * カードリポジトリインターフェース
+ *
+ * カードマスターデータ取得の契約。
+ * 参照可能な層: domain/entities, domain/enums のみ
+ */
+export interface ICardRepository {
+  findById(id: string): Card | undefined
+  findAll(): readonly Card[]
+  findByRarity(rarity: Rarity): readonly Card[]
+}

--- a/src/infrastructure/data/schemas.ts
+++ b/src/infrastructure/data/schemas.ts
@@ -29,9 +29,9 @@ export type EffectDefRaw = z.infer<typeof EffectDefSchema>
  * 自動的にスキーマも追従し、列挙値のドリフトを防ぐ。
  */
 export const CardSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string(),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
   // コスト上限は設けない（X コスト等で大きな値になる可能性がある）
   cost: z.number().int().min(0),
   card_type: z.nativeEnum(CardType),

--- a/src/infrastructure/repositories/JsonCardRepository.ts
+++ b/src/infrastructure/repositories/JsonCardRepository.ts
@@ -1,0 +1,75 @@
+import { type Card } from '../../domain/entities/Card'
+import { Rarity } from '../../domain/enums/Rarity'
+import { type ICardRepository } from '../../domain/interfaces/ICardRepository'
+import { type CardId, type EffectDef } from '../../shared/types'
+import { CardSchema, type CardRaw, type EffectDefRaw } from '../data/schemas'
+import ironcladCards from '../data/cards/ironclad.json'
+
+/**
+ * エフェクト定義の変換
+ *
+ * EffectDefRaw（Zodスキーマ型）→ EffectDef（ドメイン型）へのマッピング。
+ * 両者は構造的に同一だが、型安全性のために明示的に変換する。
+ *
+ * TODO: EffectFactory (#64) 実装時にこの関数を buildEffects(raw.effects) 呼び出しに置き換える。
+ */
+function mapEffects(rawEffects: readonly EffectDefRaw[]): readonly EffectDef[] {
+  return rawEffects.map((e) => ({
+    type: e.type,
+    value: e.value,
+    ...(e.target !== undefined && { target: e.target }),
+  }))
+}
+
+/**
+ * CardRaw（snake_case）→ Card（camelCase）へのマッパー
+ *
+ * フィールド変換:
+ *   card_type   → type       (CardSchema により CardType enum 保証済み)
+ *   target_type → targetType (CardSchema により TargetType enum 保証済み)
+ *   effects     → effects    (EffectDefRaw[] → EffectDef[])
+ */
+function toCardEntity(raw: CardRaw): Card {
+  return {
+    id: raw.id as CardId,
+    name: raw.name,
+    description: raw.description,
+    cost: raw.cost,
+    type: raw.card_type,
+    rarity: raw.rarity,
+    targetType: raw.target_type,
+    effects: mapEffects(raw.effects),
+    upgraded: raw.upgraded,
+  }
+}
+
+/**
+ * JSONファイルベースのカードリポジトリ
+ *
+ * JSONファイルをZodスキーマで検証し、Cardエンティティとして返す。
+ * 参照可能な層: domain/interfaces, domain/entities, domain/enums,
+ *               domain/value-objects, infrastructure/data
+ */
+export class JsonCardRepository implements ICardRepository {
+  private readonly cards: readonly Card[]
+
+  constructor() {
+    const rawCards = ironcladCards as unknown[]
+    this.cards = rawCards.map((raw) => {
+      const parsed = CardSchema.parse(raw)
+      return toCardEntity(parsed)
+    })
+  }
+
+  findById(id: string): Card | undefined {
+    return this.cards.find((card) => card.id === id)
+  }
+
+  findAll(): readonly Card[] {
+    return this.cards
+  }
+
+  findByRarity(rarity: Rarity): readonly Card[] {
+    return this.cards.filter((card) => card.rarity === rarity)
+  }
+}

--- a/tests/infrastructure/repositories/JsonCardRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonCardRepository.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { JsonCardRepository } from '../../../src/infrastructure/repositories/JsonCardRepository'
+import { CardType } from '../../../src/domain/enums/CardType'
+import { Rarity } from '../../../src/domain/enums/Rarity'
+import { TargetType } from '../../../src/domain/enums/TargetType'
+
+describe('JsonCardRepository', () => {
+  // 全テストで同一の read-only リポジトリを共有（毎回パースは不要）
+  let repository: JsonCardRepository
+
+  beforeAll(() => {
+    repository = new JsonCardRepository()
+  })
+
+  describe('constructor', () => {
+    it('有効な JSON ファイルでインスタンスを生成できる', () => {
+      expect(() => new JsonCardRepository()).not.toThrow()
+    })
+  })
+
+  describe('findAll', () => {
+    it('ironclad.json の全3カードを返す', () => {
+      const cards = repository.findAll()
+      expect(cards).toHaveLength(3)
+    })
+
+    it('Cardエンティティの必須フィールドが全て存在する', () => {
+      const cards = repository.findAll()
+      for (const card of cards) {
+        expect(card.id).toBeTruthy()
+        expect(card.name).toBeTruthy()
+        expect(card.description).toBeTruthy()
+        expect(typeof card.cost).toBe('number')
+        expect(Object.values(CardType)).toContain(card.type)
+        expect(Object.values(Rarity)).toContain(card.rarity)
+        expect(Object.values(TargetType)).toContain(card.targetType)
+        expect(Array.isArray(card.effects)).toBe(true)
+        expect(typeof card.upgraded).toBe('boolean')
+      }
+    })
+
+    it.todo('target を持たない effect は target フィールドを含まない（target なし effect のデータ追加時に実装）')
+  })
+
+  describe('findById', () => {
+    it('存在するIDでカードを返す', () => {
+      const card = repository.findById('strike_r')
+      expect(card).toBeDefined()
+      expect(card?.id).toBe('strike_r')
+    })
+
+    it('strike_r のフィールドが正しくマッピングされている', () => {
+      const card = repository.findById('strike_r')
+      expect(card).toBeDefined()
+      if (!card) return
+
+      expect(card.name).toBe('Strike')
+      expect(card.description).toBe('Deal 6 damage.')
+      expect(card.cost).toBe(1)
+      expect(card.type).toBe(CardType.Attack)
+      expect(card.rarity).toBe(Rarity.Common)
+      expect(card.targetType).toBe(TargetType.Single)
+      expect(card.upgraded).toBe(false)
+    })
+
+    it('strike_r の effects が正しくマッピングされている', () => {
+      const card = repository.findById('strike_r')
+      expect(card?.effects).toHaveLength(1)
+      expect(card?.effects[0]).toEqual({
+        type: 'damage',
+        value: 6,
+        target: 'single_enemy',
+      })
+    })
+
+    it('bash の複数エフェクトが正しくマッピングされている', () => {
+      const card = repository.findById('bash')
+      expect(card?.effects).toHaveLength(2)
+      expect(card?.effects[0]).toEqual({ type: 'damage', value: 8, target: 'single_enemy' })
+      expect(card?.effects[1]).toEqual({ type: 'vulnerable', value: 2, target: 'single_enemy' })
+    })
+
+    it('存在しないIDで undefined を返す', () => {
+      const card = repository.findById('nonexistent')
+      expect(card).toBeUndefined()
+    })
+
+    it('空文字IDで undefined を返す', () => {
+      const card = repository.findById('')
+      expect(card).toBeUndefined()
+    })
+  })
+
+  describe('findByRarity', () => {
+    it('Common カードを返す', () => {
+      const cards = repository.findByRarity(Rarity.Common)
+      expect(cards.length).toBeGreaterThan(0)
+      for (const card of cards) {
+        expect(card.rarity).toBe(Rarity.Common)
+      }
+    })
+
+    it('存在しないレアリティでは空配列を返す', () => {
+      // ironclad.json に Rare カードは存在しない
+      const cards = repository.findByRarity(Rarity.Rare)
+      expect(cards).toHaveLength(0)
+    })
+
+    it('findByRarity の結果は findAll の部分集合である', () => {
+      const all = repository.findAll()
+      const commons = repository.findByRarity(Rarity.Common)
+      for (const card of commons) {
+        expect(all.some((c) => c.id === card.id)).toBe(true)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Closes #33

## 変更内容

- `src/domain/interfaces/ICardRepository.ts` — カードリポジトリインターフェース（T22依存を同梱）
- `src/infrastructure/repositories/JsonCardRepository.ts` — JSON読み込み・Zodバリデーション・Cardエンティティへのマッピング実装
- `src/infrastructure/data/schemas.ts` — `CardSchema` の `id/name/description` に `min(1)` バリデーション追加
- `tests/infrastructure/repositories/JsonCardRepository.test.ts` — 13テスト（1 todo含む）

## 備考

- EffectFactory（#64）未実装のため、effects は `EffectDefRaw → EffectDef` の直接マッピング。#64 実装時に `buildEffects` 呼び出しへの置き換えが必要（#64 にコメント済み）
- ESLint がテストファイルをカバーしていない問題（MEDIUM-3）は #33 にコメント記録済み、別途対応予定

## Test plan

- [ ] `npm run typecheck` — パス確認
- [ ] `npm run lint` — パス確認
- [ ] `npm run test:run` — 116 passed / 1 todo 確認
- [ ] `findById('strike_r')` が正しいフィールドを返すことを確認
- [ ] `findByRarity(Rarity.Rare)` が空配列を返すことを確認