### PR TITLE
feat: T28 マップ生成アルゴリズム

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,5 +27,14 @@ export default tseslint.config(
       react: { version: 'detect' },
     },
   },
+  {                                                                                                         
+    extends: [...tseslint.configs.recommended],                                                             
+    files: ['tests/**/*.ts'],                                                                               
+    rules: {                                                                                                
+      '@typescript-eslint/no-explicit-any': 'error',                                                        
+      'no-shadow': 'off',                                                                                   
+      '@typescript-eslint/no-shadow': 'error',                                                              
+    },                                                                                                      
+  },                                                                                                        
   prettierConfig,
 )

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run --passWithNoTests",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix",
+    "lint": "eslint src tests",
+    "lint:fix": "eslint src tests --fix",
     "format": "prettier --write src",
     "typecheck": "tsc --noEmit",
     "prepare": "husky"

--- a/src/domain/rules/MapGenerator.ts
+++ b/src/domain/rules/MapGenerator.ts
@@ -1,5 +1,6 @@
 import type { MapNode } from '../entities/MapNode'
 import { NodeType } from '../enums/NodeType'
+import type { Seed } from '../value-objects/Seed'
 import type { NodeId } from '../../shared/types'
 
 /**
@@ -95,18 +96,18 @@ function wouldCross(conns: number[][], nodeCol: number, targetCol: number): bool
 /**
  * Slay the Spire風マップグラフを生成する純粋関数。
  *
- * @param seed - 乱数シード文字列（同じシードは同じマップを生成）
+ * @param seed - 乱数シード（同じシードは同じマップを生成）
  * @param floors - フロア総数（ボスフロアを含む）。最小2。
  * @param width - 1フロアあたりの最大ノード数（ボスフロアを除く）
  * @returns floors 要素の MapNode[][] 配列。
  *          最初のフロアは Combat のみ、最後のフロアは単一の Boss ノード。
  *
  * @remarks
- * **参照可能な層**: domain/entities, domain/enums, shared/types のみ
+ * **参照可能な層**: domain/entities, domain/enums, domain/value-objects, shared/types のみ
  * application / infrastructure / presentation には依存しない。
  */
-export function generateMap(seed: string, floors: number, width: number): MapNode[][] {
-  const rng = createPrng(seed)
+export function generateMap(seed: Seed, floors: number, width: number): MapNode[][] {
+  const rng = createPrng(seed.value)
   let nodeCounter = 0
   const makeId = (): NodeId => `node-${nodeCounter++}` as NodeId
 
@@ -182,7 +183,7 @@ export function generateMap(seed: string, floors: number, width: number): MapNod
     if (reachable.size !== nextCount) {
       throw new Error(
         `[MapGenerator] 不変条件違反: floor ${f} -> ${f + 1} にて ` +
-          `${nextCount - reachable.size} 個の次フロアノードが到達不可能 (seed="${seed}")`,
+          `${nextCount - reachable.size} 個の次フロアノードが到達不可能 (seed="${seed.value}")`,
       )
     }
 

--- a/src/domain/rules/MapGenerator.ts
+++ b/src/domain/rules/MapGenerator.ts
@@ -1,0 +1,211 @@
+import type { MapNode } from '../entities/MapNode'
+import { NodeType } from '../enums/NodeType'
+import type { NodeId } from '../../shared/types'
+
+/**
+ * 文字列シードを32bit符号なし整数にハッシュする（djb2変形）
+ */
+function hashSeed(seed: string): number {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) {
+    h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0
+  }
+  return h >>> 0
+}
+
+/**
+ * Mulberry32 疑似乱数生成器ファクトリ
+ * 同一シードから同一乱数列を生成する（決定論的）
+ */
+function createPrng(seed: string): () => number {
+  let s = hashSeed(seed)
+  return (): number => {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) | 0
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * min 以上 max 以下（両端を含む）の整数乱数を返す。
+ */
+function nextInt(rng: () => number, min: number, max: number): number {
+  return Math.floor(rng() * (max - min + 1)) + min
+}
+
+/**
+ * フロアと進行度に応じてノード種別を選択する。
+ *
+ * @param floor - 現在のフロアインデックス（0 = 最初のフロア）
+ * @param totalFloors - 全フロア数（ボスフロアを含む）
+ * @param rng - 疑似乱数生成器
+ */
+function selectNodeType(floor: number, totalFloors: number, rng: () => number): NodeType {
+  // 最初のフロアはCombatのみ
+  if (floor === 0) return NodeType.Combat
+
+  // ボス直前フロアはRest/Shop重視
+  if (floor >= totalFloors - 2) {
+    return rng() < 0.6 ? NodeType.Rest : NodeType.Shop
+  }
+
+  const progress = floor / totalFloors
+  const roll = rng()
+
+  if (progress < 0.4) {
+    // 序盤: Combat 60% / Event 20% / Elite 10% / Shop 10%
+    if (roll < 0.6) return NodeType.Combat
+    if (roll < 0.8) return NodeType.Event
+    if (roll < 0.9) return NodeType.Elite
+    return NodeType.Shop
+  } else if (progress < 0.7) {
+    // 中盤: Combat 45% / Event 20% / Elite 15% / Shop 10% / Rest 10%
+    if (roll < 0.45) return NodeType.Combat
+    if (roll < 0.65) return NodeType.Event
+    if (roll < 0.8) return NodeType.Elite
+    if (roll < 0.9) return NodeType.Shop
+    return NodeType.Rest
+  } else {
+    // 終盤: Combat 35% / Elite 20% / Rest 15% / Event 15% / Shop 15%
+    if (roll < 0.35) return NodeType.Combat
+    if (roll < 0.55) return NodeType.Elite
+    if (roll < 0.7) return NodeType.Rest
+    if (roll < 0.85) return NodeType.Event
+    return NodeType.Shop
+  }
+}
+
+/**
+ * 接続 (nodeCol → targetCol) が既存の接続群と交差するか判定する。
+ * nodeCol1 < nodeCol2 の場合、nodeCol1 の接続先 t1 は nodeCol2 の接続先 t2 以下でなければならない。
+ *
+ * @remarks 計算量は O(currentCount * nextCount)。ゲーム想定の幅（3〜7）では問題なし。
+ */
+function wouldCross(conns: number[][], nodeCol: number, targetCol: number): boolean {
+  for (let col2 = 0; col2 < conns.length; col2++) {
+    if (col2 === nodeCol) continue
+    for (const t2 of conns[col2]!) {
+      if ((nodeCol < col2 && targetCol > t2) || (nodeCol > col2 && targetCol < t2)) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Slay the Spire風マップグラフを生成する純粋関数。
+ *
+ * @param seed - 乱数シード文字列（同じシードは同じマップを生成）
+ * @param floors - フロア総数（ボスフロアを含む）。最小2。
+ * @param width - 1フロアあたりの最大ノード数（ボスフロアを除く）
+ * @returns floors 要素の MapNode[][] 配列。
+ *          最初のフロアは Combat のみ、最後のフロアは単一の Boss ノード。
+ *
+ * @remarks
+ * **参照可能な層**: domain/entities, domain/enums, shared/types のみ
+ * application / infrastructure / presentation には依存しない。
+ */
+export function generateMap(seed: string, floors: number, width: number): MapNode[][] {
+  const rng = createPrng(seed)
+  let nodeCounter = 0
+  const makeId = (): NodeId => `node-${nodeCounter++}` as NodeId
+
+  // ── Step 1: 全ノードを生成（接続情報なし）──────────────────
+  const allFloors: MapNode[][] = []
+  for (let f = 0; f < floors; f++) {
+    const isBoss = f === floors - 1
+    const nodeCount = isBoss ? 1 : nextInt(rng, 1, width)
+    const floorNodes: MapNode[] = []
+    for (let n = 0; n < nodeCount; n++) {
+      const type = isBoss ? NodeType.Boss : selectNodeType(f, floors, rng)
+      floorNodes.push({ id: makeId(), type, floor: f, connections: [], visited: false })
+    }
+    allFloors.push(floorNodes)
+  }
+
+  // ── Step 2: 接続を生成（交差なし制約） ────────────────────
+  for (let f = 0; f < floors - 1; f++) {
+    const currentFloor = allFloors[f]!
+    const nextFloor = allFloors[f + 1]!
+    const currentCount = currentFloor.length
+    const nextCount = nextFloor.length
+
+    // conns[c] = 次フロアのノードインデックスのリスト
+    const conns: number[][] = Array.from({ length: currentCount }, () => [])
+
+    // Step 2a: 比例マッピングで初期接続を割り当て
+    for (let c = 0; c < currentCount; c++) {
+      const n =
+        currentCount === 1
+          ? 0 // 単一ノードフロア: 次フロアの最初のノードへ（step 2b で補完）
+          : Math.round((c * (nextCount - 1)) / (currentCount - 1))
+      conns[c]!.push(Math.min(n, nextCount - 1))
+    }
+
+    // Step 2b: 到達不可能な次フロアノードを補完
+    //
+    // 不変条件: Step 2a の比例マッピングにより currentCount >= 1 かつ nextCount >= 1 であれば
+    // 「各次フロアノードは必ず少なくとも1つの現在フロアノードから到達可能」を保証できる。
+    // currentCount=1 の場合は単一ノードが全次フロアノードに接続され、交差は発生しない。
+    // それ以外の場合は比例マッピングで大部分がカバーされ、残りを以下で補完する。
+    // 補完できないケースは理論上存在しないが、万一発生した場合は後段の不変条件チェックで検出する。
+    const reachable = new Set<number>()
+    for (const cs of conns) for (const t of cs) reachable.add(t)
+
+    for (let t = 0; t < nextCount; t++) {
+      if (reachable.has(t)) continue
+      // 比例的に最も近い現在フロアノードを探す
+      const targetC = Math.round((t * (currentCount - 1)) / Math.max(nextCount - 1, 1))
+      const c = Math.min(targetC, currentCount - 1)
+      if (!conns[c]!.includes(t) && !wouldCross(conns, c, t)) {
+        conns[c]!.push(t)
+        reachable.add(t)
+      } else {
+        // 交差なしで接続可能なノードを左右方向に探索
+        for (let delta = 1; delta < currentCount; delta++) {
+          for (const dc of [delta, -delta]) {
+            const c2 = c + dc
+            if (c2 < 0 || c2 >= currentCount) continue
+            if (!conns[c2]!.includes(t) && !wouldCross(conns, c2, t)) {
+              conns[c2]!.push(t)
+              reachable.add(t)
+              break
+            }
+          }
+          if (reachable.has(t)) break
+        }
+      }
+    }
+
+    // 不変条件チェック: 全次フロアノードが到達可能であること
+    /* istanbul ignore next -- アルゴリズムの不変条件違反は開発時に検出するためのガード */
+    if (reachable.size !== nextCount) {
+      throw new Error(
+        `[MapGenerator] 不変条件違反: floor ${f} -> ${f + 1} にて ` +
+          `${nextCount - reachable.size} 個の次フロアノードが到達不可能 (seed="${seed}")`,
+      )
+    }
+
+    // Step 2c: ランダムな追加接続（最大2本/ノード、40%の確率）
+    for (let c = 0; c < currentCount; c++) {
+      if (conns[c]!.length >= 2 || rng() >= 0.4) continue
+      const existing = conns[c]![0]!
+      for (const delta of [-1, 1]) {
+        const n = existing + delta
+        if (n >= 0 && n < nextCount && !conns[c]!.includes(n) && !wouldCross(conns, c, n)) {
+          conns[c]!.push(n)
+          break
+        }
+      }
+    }
+
+    // 接続情報をノードに適用（不変オブジェクト生成）
+    for (let c = 0; c < currentCount; c++) {
+      const node = currentFloor[c]!
+      const connIds: readonly NodeId[] = conns[c]!.map((n) => nextFloor[n]!.id)
+      allFloors[f]![c] = { ...node, connections: connIds }
+    }
+  }
+
+  return allFloors
+}

--- a/tests/domain/rules/MapGenerator.test.ts
+++ b/tests/domain/rules/MapGenerator.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import { generateMap } from '../../../src/domain/rules/MapGenerator'
 import { NodeType } from '../../../src/domain/enums/NodeType'
+import { Seed } from '../../../src/domain/value-objects/Seed'
 
-const SEED = 'test-seed-42'
+// テスト用シードヘルパー（Seed.create の Result アンラップを一元化）
+function makeSeed(value: string): Seed {
+  const result = Seed.create(value)
+  if (!result.ok) throw new Error(`Invalid seed: ${result.error}`)
+  return result.value
+}
+
+const SEED = makeSeed('test-seed-42')
 const FLOORS = 15
 const WIDTH = 3
 
@@ -33,7 +41,7 @@ describe('generateMap - return shape', () => {
 
   it('every node has a unique id', () => {
     const map = generateMap(SEED, FLOORS, WIDTH)
-    const ids = map.flat().map(n => n.id)
+    const ids = map.flat().map((n) => n.id)
     expect(new Set(ids).size).toBe(ids.length)
   })
 
@@ -114,7 +122,7 @@ describe('generateMap - floor constraints', () => {
   it('Elite and Rest never appear on floor 0', () => {
     // Run many times to be statistically confident
     for (let i = 0; i < 20; i++) {
-      const map = generateMap(`seed-${i}`, FLOORS, WIDTH)
+      const map = generateMap(makeSeed(`seed-${i}`), FLOORS, WIDTH)
       for (const node of map[0]!) {
         expect(node.type).not.toBe(NodeType.Elite)
         expect(node.type).not.toBe(NodeType.Rest)
@@ -137,7 +145,7 @@ describe('generateMap - node types', () => {
 
   it('a large map contains non-Combat variety', () => {
     const map = generateMap(SEED, 15, 4)
-    const types = map.flat().map(n => n.type)
+    const types = map.flat().map((n) => n.type)
     const unique = new Set(types)
     expect(unique.size).toBeGreaterThan(1)
   })
@@ -159,7 +167,7 @@ describe('generateMap - connectivity', () => {
   it('all connections reference valid NodeIds on the next floor', () => {
     const map = generateMap(SEED, FLOORS, WIDTH)
     for (let f = 0; f < FLOORS - 1; f++) {
-      const nextIds = new Set(map[f + 1]!.map(n => n.id))
+      const nextIds = new Set(map[f + 1]!.map((n) => n.id))
       for (const node of map[f]!) {
         for (const connId of node.connections) {
           expect(nextIds.has(connId)).toBe(true)
@@ -210,8 +218,8 @@ describe('generateMap - no crossing connections', () => {
 
       for (let c1 = 0; c1 < currentFloor.length; c1++) {
         for (let c2 = c1 + 1; c2 < currentFloor.length; c2++) {
-          const conns1 = currentFloor[c1]!.connections.map(id => nextIdToIndex.get(id)!)
-          const conns2 = currentFloor[c2]!.connections.map(id => nextIdToIndex.get(id)!)
+          const conns1 = currentFloor[c1]!.connections.map((id) => nextIdToIndex.get(id)!)
+          const conns2 = currentFloor[c2]!.connections.map((id) => nextIdToIndex.get(id)!)
           // c1 is left of c2, so all targets from c1 must be <= all targets from c2
           for (const n1 of conns1) {
             for (const n2 of conns2) {
@@ -237,7 +245,7 @@ describe('generateMap - no crossing connections', () => {
 
   it('no connections cross with multiple seeds', () => {
     for (let i = 0; i < 10; i++) {
-      checkNoCrossings(generateMap(`cross-seed-${i}`, 10, 4))
+      checkNoCrossings(generateMap(makeSeed(`cross-seed-${i}`), 10, 4))
     }
   })
 })
@@ -253,10 +261,16 @@ describe('generateMap - determinism', () => {
   })
 
   it('different seeds produce different maps', () => {
-    const map1 = generateMap('alpha-seed', FLOORS, WIDTH)
-    const map2 = generateMap('beta-seed', FLOORS, WIDTH)
-    const types1 = map1.flat().map(n => n.type).join(',')
-    const types2 = map2.flat().map(n => n.type).join(',')
+    const map1 = generateMap(makeSeed('alpha-seed'), FLOORS, WIDTH)
+    const map2 = generateMap(makeSeed('beta-seed'), FLOORS, WIDTH)
+    const types1 = map1
+      .flat()
+      .map((n) => n.type)
+      .join(',')
+    const types2 = map2
+      .flat()
+      .map((n) => n.type)
+      .join(',')
     expect(types1).not.toBe(types2)
   })
 

--- a/tests/domain/rules/MapGenerator.test.ts
+++ b/tests/domain/rules/MapGenerator.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest'
+import { generateMap } from '../../../src/domain/rules/MapGenerator'
+import { NodeType } from '../../../src/domain/enums/NodeType'
+
+const SEED = 'test-seed-42'
+const FLOORS = 15
+const WIDTH = 3
+
+// ──────────────────────────────────────────────────────────
+// Return shape
+// ──────────────────────────────────────────────────────────
+describe('generateMap - return shape', () => {
+  it('returns `floors` floor arrays', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map).toHaveLength(FLOORS)
+  })
+
+  it('each floor is an array', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (const floor of map) {
+      expect(Array.isArray(floor)).toBe(true)
+    }
+  })
+
+  it('node.floor matches its array index', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 0; f < FLOORS; f++) {
+      for (const node of map[f]!) {
+        expect(node.floor).toBe(f)
+      }
+    }
+  })
+
+  it('every node has a unique id', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    const ids = map.flat().map(n => n.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('visited is false on every node', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (const node of map.flat()) {
+      expect(node.visited).toBe(false)
+    }
+  })
+
+  it('connections is an array on every node', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (const node of map.flat()) {
+      expect(Array.isArray(node.connections)).toBe(true)
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// Floor constraints
+// ──────────────────────────────────────────────────────────
+describe('generateMap - floor constraints', () => {
+  it('floor 0 contains only Combat nodes', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (const node of map[0]!) {
+      expect(node.type).toBe(NodeType.Combat)
+    }
+  })
+
+  it('floor 0 has at least one node', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map[0]!.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('floor 0 has at most width nodes', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map[0]!.length).toBeLessThanOrEqual(WIDTH)
+  })
+
+  it('boss floor (last) contains exactly one node', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map[FLOORS - 1]!).toHaveLength(1)
+  })
+
+  it('boss floor node has type Boss', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map[FLOORS - 1]![0]!.type).toBe(NodeType.Boss)
+  })
+
+  it('boss floor node has no outgoing connections', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    expect(map[FLOORS - 1]![0]!.connections).toHaveLength(0)
+  })
+
+  it('middle floors are non-empty', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 1; f < FLOORS - 1; f++) {
+      expect(map[f]!.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('middle floors have at most width nodes', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 1; f < FLOORS - 1; f++) {
+      expect(map[f]!.length).toBeLessThanOrEqual(WIDTH)
+    }
+  })
+
+  it('Boss type never appears before the final floor', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 0; f < FLOORS - 1; f++) {
+      for (const node of map[f]!) {
+        expect(node.type).not.toBe(NodeType.Boss)
+      }
+    }
+  })
+
+  it('Elite and Rest never appear on floor 0', () => {
+    // Run many times to be statistically confident
+    for (let i = 0; i < 20; i++) {
+      const map = generateMap(`seed-${i}`, FLOORS, WIDTH)
+      for (const node of map[0]!) {
+        expect(node.type).not.toBe(NodeType.Elite)
+        expect(node.type).not.toBe(NodeType.Rest)
+      }
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// Node type distribution
+// ──────────────────────────────────────────────────────────
+describe('generateMap - node types', () => {
+  it('only valid NodeType values appear', () => {
+    const validTypes = new Set<string>(Object.values(NodeType))
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (const node of map.flat()) {
+      expect(validTypes.has(node.type)).toBe(true)
+    }
+  })
+
+  it('a large map contains non-Combat variety', () => {
+    const map = generateMap(SEED, 15, 4)
+    const types = map.flat().map(n => n.type)
+    const unique = new Set(types)
+    expect(unique.size).toBeGreaterThan(1)
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// Connectivity
+// ──────────────────────────────────────────────────────────
+describe('generateMap - connectivity', () => {
+  it('non-boss nodes each have at least one outgoing connection', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 0; f < FLOORS - 1; f++) {
+      for (const node of map[f]!) {
+        expect(node.connections.length).toBeGreaterThanOrEqual(1)
+      }
+    }
+  })
+
+  it('all connections reference valid NodeIds on the next floor', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 0; f < FLOORS - 1; f++) {
+      const nextIds = new Set(map[f + 1]!.map(n => n.id))
+      for (const node of map[f]!) {
+        for (const connId of node.connections) {
+          expect(nextIds.has(connId)).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('every node on floor f>0 has at least one incoming connection', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    for (let f = 1; f < FLOORS; f++) {
+      const reachable = new Set<string>()
+      for (const node of map[f - 1]!) {
+        for (const id of node.connections) reachable.add(id)
+      }
+      for (const node of map[f]!) {
+        expect(reachable.has(node.id)).toBe(true)
+      }
+    }
+  })
+
+  it('connections never skip floors', () => {
+    const map = generateMap(SEED, FLOORS, WIDTH)
+    const allNodeIds = new Map<string, number>()
+    for (let f = 0; f < FLOORS; f++) {
+      for (const node of map[f]!) allNodeIds.set(node.id, f)
+    }
+    for (let f = 0; f < FLOORS - 1; f++) {
+      for (const node of map[f]!) {
+        for (const connId of node.connections) {
+          expect(allNodeIds.get(connId)).toBe(f + 1)
+        }
+      }
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// No crossing connections
+// ──────────────────────────────────────────────────────────
+describe('generateMap - no crossing connections', () => {
+  function checkNoCrossings(map: ReturnType<typeof generateMap>): void {
+    const floors = map.length
+    for (let f = 0; f < floors - 1; f++) {
+      const currentFloor = map[f]!
+      const nextFloor = map[f + 1]!
+      const nextIdToIndex = new Map(nextFloor.map((n, i) => [n.id, i]))
+
+      for (let c1 = 0; c1 < currentFloor.length; c1++) {
+        for (let c2 = c1 + 1; c2 < currentFloor.length; c2++) {
+          const conns1 = currentFloor[c1]!.connections.map(id => nextIdToIndex.get(id)!)
+          const conns2 = currentFloor[c2]!.connections.map(id => nextIdToIndex.get(id)!)
+          // c1 is left of c2, so all targets from c1 must be <= all targets from c2
+          for (const n1 of conns1) {
+            for (const n2 of conns2) {
+              expect(n1).toBeLessThanOrEqual(n2)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it('no connections cross with width=3', () => {
+    checkNoCrossings(generateMap(SEED, FLOORS, 3))
+  })
+
+  it('no connections cross with width=2', () => {
+    checkNoCrossings(generateMap(SEED, FLOORS, 2))
+  })
+
+  it('no connections cross with width=5', () => {
+    checkNoCrossings(generateMap(SEED, FLOORS, 5))
+  })
+
+  it('no connections cross with multiple seeds', () => {
+    for (let i = 0; i < 10; i++) {
+      checkNoCrossings(generateMap(`cross-seed-${i}`, 10, 4))
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// Determinism
+// ──────────────────────────────────────────────────────────
+describe('generateMap - determinism', () => {
+  it('same seed + same arguments produce identical maps', () => {
+    const map1 = generateMap(SEED, FLOORS, WIDTH)
+    const map2 = generateMap(SEED, FLOORS, WIDTH)
+    expect(map1).toEqual(map2)
+  })
+
+  it('different seeds produce different maps', () => {
+    const map1 = generateMap('alpha-seed', FLOORS, WIDTH)
+    const map2 = generateMap('beta-seed', FLOORS, WIDTH)
+    const types1 = map1.flat().map(n => n.type).join(',')
+    const types2 = map2.flat().map(n => n.type).join(',')
+    expect(types1).not.toBe(types2)
+  })
+
+  it('returned arrays are distinct references across calls', () => {
+    const map1 = generateMap(SEED, FLOORS, WIDTH)
+    const map2 = generateMap(SEED, FLOORS, WIDTH)
+    expect(map1).not.toBe(map2)
+    expect(map1[0]).not.toBe(map2[0])
+    expect(map1[0]![0]).not.toBe(map2[0]![0])
+  })
+})
+
+// ──────────────────────────────────────────────────────────
+// Edge cases
+// ──────────────────────────────────────────────────────────
+describe('generateMap - edge cases', () => {
+  it('floors=2: floor[0]=Combat, floor[1]=Boss', () => {
+    const map = generateMap(SEED, 2, 3)
+    expect(map).toHaveLength(2)
+    for (const node of map[0]!) {
+      expect(node.type).toBe(NodeType.Combat)
+    }
+    expect(map[1]![0]!.type).toBe(NodeType.Boss)
+  })
+
+  it('width=1: every floor has exactly one node (linear map)', () => {
+    const map = generateMap(SEED, 5, 1)
+    for (const floor of map) {
+      expect(floor).toHaveLength(1)
+    }
+  })
+
+  it('width=1: each node has exactly one connection (except boss)', () => {
+    const map = generateMap(SEED, 5, 1)
+    for (let f = 0; f < 4; f++) {
+      expect(map[f]![0]!.connections).toHaveLength(1)
+    }
+    expect(map[4]![0]!.connections).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #28

## 実装内容
- `src/domain/rules/MapGenerator.ts` — `generateMap(seed, floors, width): MapNode[][]` 純粋関数
- `tests/domain/rules/MapGenerator.test.ts` — 32テスト（TDD: RED→GREEN→REFACTOR）

## アルゴリズム概要
- **PRNG**: Mulberry32（文字列シード → djb2ハッシュ → 決定論的乱数列）
- **ノード種別**: 序盤/中盤/終盤で加重ランダム。フロア0はCombatのみ、ボス直前はRest/Shop重視
- **接続生成**: 比例マッピング + `wouldCross` による交差なし保証 + 到達可能性 runtime guard

## テスト計画
- [x] return shape（形状・一意ID・visited=false）
- [x] floor constraints（フロア0=Combatのみ、ボスフロア=単一Boss）
- [x] node types（有効な NodeType のみ、Boss は最終フロアのみ）
- [x] connectivity（全ノード到達可能、接続先は次フロアのみ）
- [x] no crossing connections（幅2/3/5、複数シードで検証）
- [x] determinism（同一シード→同一マップ、異なるシード→異なるマップ）
- [x] edge cases（width=1 の線形マップ、floors=2 の最小マップ）

## その他
- ESLint を `tests/` にも適用（`lint:fix` も更新）
- ESLint 未対象問題を issue #42 にコメントして記録済み