### PR TITLE
feat: T17 T20 T24 T35 エンティティ定義・セーブリポジトリ実装

### DIFF
--- a/src/domain/entities/Combat.ts
+++ b/src/domain/entities/Combat.ts
@@ -1,0 +1,23 @@
+import { type CombatPhase } from '../enums/CombatPhase'
+import { type Enemy } from './Enemy'
+import { type Player } from './Player'
+
+/**
+ * 戦闘状態エンティティ
+ *
+ * 1回の戦闘における現在の状態スナップショットを表すエンティティ。
+ * 全プロパティは readonly（イミュータビリティ必須）。
+ *
+ * - activePowers フィールドは Combat に持たせない設計。
+ *   Power（筋力・アーティファクト等）は Player および Enemy 各自の
+ *   powers: readonly ActivePower[] プロパティとして保持する。
+ * - turn は 1 始まりのターン数を表す
+ *
+ * 参照可能な層: domain/entities, domain/enums のみ
+ */
+export interface Combat {
+  readonly player: Player
+  readonly enemies: readonly Enemy[]
+  readonly turn: number
+  readonly phase: CombatPhase
+}

--- a/src/domain/entities/Enemy.ts
+++ b/src/domain/entities/Enemy.ts
@@ -1,0 +1,42 @@
+import { type EnemyId } from '../../shared/types'
+import { type Character } from './Character'
+
+/**
+ * インテントタイプ
+ *
+ * 敵キャラクターが次のターンに実行する行動の種別。
+ * - attack: 攻撃（value = ダメージ量）
+ * - block: ブロック（value = ブロック量）
+ * - buff: バフ（筋力付与等）
+ * - debuff: デバフ（脆弱・衰弱付与等）
+ * - unknown: 不明（ゲーム開始直後等）
+ */
+export type IntentType = 'attack' | 'block' | 'buff' | 'debuff' | 'unknown'
+
+/**
+ * インテント
+ *
+ * 敵キャラクターが次のターンに実行する行動の情報。
+ * value は行動の種別に応じた数値（ダメージ量・ブロック量等）を表す。
+ */
+export type Intent = {
+  readonly type: IntentType
+  readonly value?: number
+}
+
+/**
+ * 敵エンティティ
+ *
+ * 敵キャラクター固有の情報（インテント・敵ID）を持つエンティティ。
+ * Character インターフェースを実装し、共通の戦闘プロパティ（health/block/powers/statusEffects）を持つ。
+ *
+ * - powers プロパティは Combatant 経由で保持（Combat には持たせない設計）
+ * - intent は次のターンに実行する行動の種別と数値
+ * - enemyId は敵の種別識別子（例: 'jaw_worm'）
+ *
+ * 参照可能な層: domain/value-objects, domain/entities のみ
+ */
+export interface Enemy extends Character {
+  readonly enemyId: EnemyId
+  readonly intent: Intent
+}

--- a/src/domain/enums/CombatPhase.ts
+++ b/src/domain/enums/CombatPhase.ts
@@ -1,0 +1,12 @@
+/**
+ * 戦闘フェーズ
+ *
+ * 1回の戦闘における現在のフェーズを表す列挙型。
+ * Combat エンティティの phase プロパティで使用する。
+ */
+export enum CombatPhase {
+  PlayerTurn = 'PlayerTurn',
+  EnemyTurn = 'EnemyTurn',
+  Victory = 'Victory',
+  Defeat = 'Defeat',
+}

--- a/src/domain/interfaces/ISaveRepository.ts
+++ b/src/domain/interfaces/ISaveRepository.ts
@@ -1,0 +1,14 @@
+import { type Player } from '../entities/Player'
+
+/**
+ * セーブリポジトリインターフェース
+ *
+ * ラン途中のセーブデータ保存・読込の契約。
+ * 参照可能な層: domain/entities のみ
+ */
+export interface ISaveRepository {
+  save(state: Player): void
+  load(): Player | null
+  delete(): void
+  exists(): boolean
+}

--- a/src/infrastructure/repositories/LocalStorageSaveRepository.ts
+++ b/src/infrastructure/repositories/LocalStorageSaveRepository.ts
@@ -1,0 +1,55 @@
+import { type Player } from '../../domain/entities/Player'
+import { type ISaveRepository } from '../../domain/interfaces/ISaveRepository'
+
+const SAVE_KEY = 'xxx-the-spire-save'
+const SAVE_VERSION = 1
+
+type SaveData = {
+  readonly version: number
+  readonly data: unknown
+}
+
+/**
+ * localStorageベースのセーブリポジトリ
+ *
+ * ISaveRepository の実装クラス。
+ * バージョン付き JSON としてラン状態を localStorage に永続化する。
+ * バージョンフィールドにより将来的なマイグレーション対応が可能。
+ *
+ * 参照可能な層: domain/interfaces, domain/entities
+ */
+export class LocalStorageSaveRepository implements ISaveRepository {
+  save(state: Player): void {
+    const saveData: SaveData = {
+      version: SAVE_VERSION,
+      data: state,
+    }
+    localStorage.setItem(SAVE_KEY, JSON.stringify(saveData))
+  }
+
+  load(): Player | null {
+    const raw = localStorage.getItem(SAVE_KEY)
+    if (raw === null) return null
+
+    let parsed: SaveData
+    try {
+      parsed = JSON.parse(raw) as SaveData
+    } catch {
+      return null
+    }
+
+    if (parsed.version !== SAVE_VERSION) return null
+
+    // TODO: T51 で SerializedPlayer スキーマによる構造バリデーションと
+    // クラスインスタンス再構築（Health/Block/Energy/Gold 等）を実装する。
+    return parsed.data as unknown as Player
+  }
+
+  delete(): void {
+    localStorage.removeItem(SAVE_KEY)
+  }
+
+  exists(): boolean {
+    return localStorage.getItem(SAVE_KEY) !== null
+  }
+}

--- a/tests/infrastructure/repositories/LocalStorageSaveRepository.test.ts
+++ b/tests/infrastructure/repositories/LocalStorageSaveRepository.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { LocalStorageSaveRepository } from '../../../src/infrastructure/repositories/LocalStorageSaveRepository'
+import type { Player } from '../../../src/domain/entities/Player'
+
+/**
+ * Player インターフェースを満たす最小限のモックオブジェクト。
+ * Health/Block/Energy/Gold はクラスインスタンスではなく
+ * 構造的に互換な plain object として扱う。
+ */
+const mockPlayer: Player = {
+  id: 'ironclad',
+  name: 'Ironclad',
+  health: { current: 80, max: 80 } as Player['health'],
+  block: { value: 0 } as Player['block'],
+  powers: [],
+  statusEffects: [],
+  energy: { current: 3, max: 3 } as Player['energy'],
+  gold: { amount: 99 } as Player['gold'],
+  deck: [],
+  hand: [],
+  discardPile: [],
+  exhaustPile: [],
+  relics: [],
+  maxPotionSlots: 3,
+  potions: [null, null, null],
+}
+
+describe('LocalStorageSaveRepository', () => {
+  let repository: LocalStorageSaveRepository
+
+  beforeEach(() => {
+    localStorage.clear()
+    repository = new LocalStorageSaveRepository()
+  })
+
+  describe('exists', () => {
+    it('セーブデータが存在しない場合は false を返す', () => {
+      expect(repository.exists()).toBe(false)
+    })
+
+    it('save 後は true を返す', () => {
+      repository.save(mockPlayer)
+      expect(repository.exists()).toBe(true)
+    })
+  })
+
+  describe('save / load', () => {
+    it('セーブデータが存在しない場合は null を返す', () => {
+      expect(repository.load()).toBeNull()
+    })
+
+    it('save したデータを load で取得できる', () => {
+      repository.save(mockPlayer)
+      const loaded = repository.load()
+      expect(loaded).not.toBeNull()
+      expect(loaded?.id).toBe('ironclad')
+      expect(loaded?.health).toEqual({ current: 80, max: 80 })
+      expect(loaded?.gold).toEqual({ amount: 99 })
+    })
+
+    it('localStorage にバージョンフィールド付きで保存される', () => {
+      repository.save(mockPlayer)
+      const raw = localStorage.getItem('xxx-the-spire-save')
+      expect(raw).not.toBeNull()
+      const parsed = JSON.parse(raw!) as { version: number; data: unknown }
+      expect(parsed.version).toBe(1)
+      expect(parsed.data).toBeDefined()
+    })
+  })
+
+  describe('delete', () => {
+    it('save 後に delete すると exists が false になる', () => {
+      repository.save(mockPlayer)
+      repository.delete()
+      expect(repository.exists()).toBe(false)
+    })
+
+    it('delete 後は load が null を返す', () => {
+      repository.save(mockPlayer)
+      repository.delete()
+      expect(repository.load()).toBeNull()
+    })
+  })
+
+  describe('バージョン不一致', () => {
+    it('保存データのバージョンが異なる場合は null を返す', () => {
+      localStorage.setItem('xxx-the-spire-save', JSON.stringify({ version: 999, data: mockPlayer }))
+      expect(repository.load()).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **T17**: `Enemy` エンティティ — `intent`（次ターン行動）・`enemyId` を追加、`Character` 経由で `Combatant` 実装
- **T20**: `CombatPhase` enum + `Combat` エンティティ — `activePowers` は Combat に持たせない設計、全プロパティ `readonly`
- **T24**: `ISaveRepository` インターフェース — `save / load / delete / exists` の契約定義
- **T35**: `LocalStorageSaveRepository` 実装 — バージョン付き JSON 永続化、`@vitest-environment jsdom` でTDD（8テスト）

## 設計メモ

- `load()` の `JSON.parse` を `try/catch` で囲みクラッシュ防止済み
- デシリアライズ後のクラスインスタンス再構築（`Health`/`Block` 等）と Zod バリデーションは T51 で対応（[#51 コメント参照](https://github.com/xzodias/XxxTheSpire/issues/51#issuecomment-4168416857)）

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:run` 通過（171 tests）
- [x] `LocalStorageSaveRepository` jsdom 環境で 8 テスト GREEN

Closes #17, #20, #24, #35