### PR TITLE
feat: T42 T59 StartRunUseCase・DIコンテナ実装

### DIFF
--- a/src/application/usecases/StartRunUseCase.ts
+++ b/src/application/usecases/StartRunUseCase.ts
@@ -1,0 +1,82 @@
+import { type Result, ok, err } from '../../shared/types'
+import { Health } from '../../domain/value-objects/Health'
+import { Energy } from '../../domain/value-objects/Energy'
+import { Gold } from '../../domain/value-objects/Gold'
+import { Block } from '../../domain/value-objects/Block'
+import { type Seed } from '../../domain/value-objects/Seed'
+import { type Player } from '../../domain/entities/Player'
+import { type MapNode } from '../../domain/entities/MapNode'
+import { type Card } from '../../domain/entities/Card'
+import { type ICardRepository } from '../../domain/interfaces/ICardRepository'
+import { generateMap } from '../../domain/rules/MapGenerator'
+import {
+  STARTING_ENERGY,
+  MAX_ENERGY,
+  STARTING_GOLD,
+  MAX_POTIONS,
+  MAP_FLOORS_PER_ACT,
+  MAP_WIDTH,
+  IRONCLAD_STARTING_HP,
+  IRONCLAD_STARTING_DECK,
+} from '../../shared/constants'
+
+export class StartRunUseCase {
+  constructor(private readonly cardRepo: ICardRepository) {}
+
+  execute(characterId: string, seed: Seed): Result<{ player: Player; map: MapNode[][] }, string> {
+    // TODO: T111 CharacterRepository 実装後、ICharacterRepository.findById(characterId) に置き換える。
+    // 現在は Ironclad のみ対応（暫定実装）。
+    if (characterId !== 'ironclad') {
+      return err('unknown character')
+    }
+
+    // Build initial deck
+    const deck: Card[] = []
+    for (const { id, count } of IRONCLAD_STARTING_DECK) {
+      const card = this.cardRepo.findById(id)
+      if (card === undefined) {
+        return err(`Card not found: ${id}`)
+      }
+      for (let i = 0; i < count; i++) {
+        deck.push(card)
+      }
+    }
+
+    // Create value objects
+    const healthResult = Health.create(IRONCLAD_STARTING_HP, IRONCLAD_STARTING_HP)
+    if (!healthResult.ok) return err(healthResult.error)
+
+    const energyResult = Energy.create(STARTING_ENERGY, MAX_ENERGY)
+    if (!energyResult.ok) return err(energyResult.error)
+
+    const goldResult = Gold.create(STARTING_GOLD)
+    if (!goldResult.ok) return err(goldResult.error)
+
+    const blockResult = Block.create(0)
+    if (!blockResult.ok) return err(blockResult.error)
+
+    // Build player
+    const player: Player = {
+      id: 'ironclad',
+      name: 'Ironclad',
+      health: healthResult.value,
+      energy: energyResult.value,
+      gold: goldResult.value,
+      block: blockResult.value,
+      deck,
+      hand: [],
+      discardPile: [],
+      exhaustPile: [],
+      relics: [],
+      powers: [],
+      statusEffects: [],
+      potions: Array.from<null>({ length: MAX_POTIONS }).fill(null),
+      maxPotionSlots: MAX_POTIONS,
+    }
+
+    // Generate map
+    const map = generateMap(seed, MAP_FLOORS_PER_ACT, MAP_WIDTH)
+
+    return ok({ player, map })
+  }
+}

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -9,9 +9,9 @@ import { LocalStorageSaveRepository } from '../infrastructure/repositories/Local
 import { SeededRandomService } from '../infrastructure/services/SeededRandomService'
 import { StartRunUseCase } from '../application/usecases/StartRunUseCase'
 
-// NOTE: StartRunUseCase は具象クラス型で公開している（IStartRunUseCase インターフェース化は不要）。
+// NOTE: StartRunUseCase は具象クラス型で公開している（IStartRunUseCase インターフェース化は意図的に省略）。
 // UseCase はリポジトリと異なり実装の差し替え需要がなく、テストは UseCase 単体にモック依存を渡す形で行う。
-// この設計判断は意識的なもの（architect レビュー承認済み）。
+// 他の依存がインターフェース型である点との非対称は認識済みの意識的な設計判断。
 
 /**
  * DIコンテナの型定義
@@ -24,7 +24,7 @@ export type Container = {
   readonly cardRepository: ICardRepository
   readonly relicRepository: IRelicRepository
   readonly saveRepository: ISaveRepository
-  readonly startRunUseCase: StartRunUseCase // 具象クラス型（意識的設計。上記 NOTE 参照）
+  readonly startRunUseCase: StartRunUseCase // 具象クラス型（意識的設計。上記 NOTE 参照）。
 }
 
 /**

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -1,0 +1,57 @@
+import { type ICardRepository } from '../domain/interfaces/ICardRepository'
+import { type IRandomService } from '../domain/interfaces/IRandomService'
+import { type IRelicRepository } from '../domain/interfaces/IRelicRepository'
+import { type ISaveRepository } from '../domain/interfaces/ISaveRepository'
+import type { Seed } from '../domain/value-objects/Seed'
+import { JsonCardRepository } from '../infrastructure/repositories/JsonCardRepository'
+import { JsonRelicRepository } from '../infrastructure/repositories/JsonRelicRepository'
+import { LocalStorageSaveRepository } from '../infrastructure/repositories/LocalStorageSaveRepository'
+import { SeededRandomService } from '../infrastructure/services/SeededRandomService'
+import { StartRunUseCase } from '../application/usecases/StartRunUseCase'
+
+// NOTE: StartRunUseCase は具象クラス型で公開している（IStartRunUseCase インターフェース化は不要）。
+// UseCase はリポジトリと異なり実装の差し替え需要がなく、テストは UseCase 単体にモック依存を渡す形で行う。
+// この設計判断は意識的なもの（architect レビュー承認済み）。
+
+/**
+ * DIコンテナの型定義
+ *
+ * createContainer が返す全サービス・ユースケースの集合型。
+ * presentation 層はこの型を通じて依存を受け取る。
+ */
+export type Container = {
+  readonly randomService: IRandomService
+  readonly cardRepository: ICardRepository
+  readonly relicRepository: IRelicRepository
+  readonly saveRepository: ISaveRepository
+  readonly startRunUseCase: StartRunUseCase // 具象クラス型（意識的設計。上記 NOTE 参照）
+}
+
+/**
+ * DIコンテナファクトリ
+ *
+ * ランごとに呼び出し、全インフラ実装・ユースケースをワイヤリングして返す。
+ * 手動DI（ライブラリ不使用）により TypeScript の型安全性を完全に活用できる。
+ *
+ * @param seed - ランのシード。SeededRandomService の決定論的再現性を保証するために必須。
+ *
+ * @remarks
+ * **参照可能な層**: 全層（DI層として特別扱い）
+ * presentationから呼ばれる唯一のエントリポイント。
+ */
+export function createContainer(seed: Seed): Container {
+  const randomService = new SeededRandomService(seed)
+  const cardRepository = new JsonCardRepository()
+  const relicRepository = new JsonRelicRepository()
+  const saveRepository = new LocalStorageSaveRepository()
+
+  const startRunUseCase = new StartRunUseCase(cardRepository)
+
+  return {
+    randomService,
+    cardRepository,
+    relicRepository,
+    saveRepository,
+    startRunUseCase,
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,3 +1,5 @@
+import { type CardId } from './types'
+
 // Hand & Deck
 export const MAX_HAND_SIZE = 10
 export const STARTING_DRAW_COUNT = 5
@@ -11,6 +13,21 @@ export const MAX_ENERGY = 3
 
 // HP
 export const MAX_HP_CAP = 999
+
+// Character starting HP
+// TODO: T111 CharacterRepository 実装後、この定数を削除して ICharacterRepository 経由に移行する。
+export const IRONCLAD_STARTING_HP = 80
+
+// Ironclad starting deck definition (card id → count)
+// TODO: T111 CharacterRepository 実装後、この定数を削除して ICharacterRepository 経由に移行する。
+export const IRONCLAD_STARTING_DECK: ReadonlyArray<{
+  readonly id: CardId
+  readonly count: number
+}> = [
+  { id: 'strike_r' as CardId, count: 5 },
+  { id: 'defend_r' as CardId, count: 4 },
+  { id: 'bash' as CardId, count: 1 },
+]
 
 // Gold
 export const STARTING_GOLD = 99

--- a/tests/application/usecases/StartRunUseCase.test.ts
+++ b/tests/application/usecases/StartRunUseCase.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StartRunUseCase } from '../../../src/application/usecases/StartRunUseCase'
+import { type ICardRepository } from '../../../src/domain/interfaces/ICardRepository'
+import { type Card } from '../../../src/domain/entities/Card'
+import { Seed } from '../../../src/domain/value-objects/Seed'
+import { CardType } from '../../../src/domain/enums/CardType'
+import { Rarity } from '../../../src/domain/enums/Rarity'
+import { TargetType } from '../../../src/domain/enums/TargetType'
+import { type CardId } from '../../../src/shared/types'
+import { MAP_FLOORS_PER_ACT } from '../../../src/shared/constants'
+
+// --- Test helpers ---
+
+function createMockCard(id: string): Card {
+  return {
+    id: id as CardId,
+    name: id,
+    description: `${id} description`,
+    cost: 1,
+    type: CardType.Attack,
+    rarity: Rarity.Common,
+    targetType: TargetType.Single,
+    effects: [],
+    upgraded: false,
+  }
+}
+
+// --- Mocks ---
+
+function buildCardRepo(overrides?: Partial<Record<string, Card | undefined>>): ICardRepository {
+  const defaultCards: Record<string, Card> = {
+    strike_r: createMockCard('strike_r'),
+    defend_r: createMockCard('defend_r'),
+    bash: createMockCard('bash'),
+  }
+  const cards = { ...defaultCards, ...overrides }
+  return {
+    findById: vi.fn((id: string) => cards[id]),
+    findAll: vi.fn(() => []),
+    findByRarity: vi.fn(() => []),
+  }
+}
+
+function createSeed(): Seed {
+  const result = Seed.create('test-seed-42')
+  if (!result.ok) throw new Error('Failed to create seed')
+  return result.value
+}
+
+// --- Tests ---
+
+describe('StartRunUseCase', () => {
+  let cardRepo: ICardRepository
+  let seed: Seed
+  let usecase: StartRunUseCase
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cardRepo = buildCardRepo()
+    seed = createSeed()
+    usecase = new StartRunUseCase(cardRepo)
+  })
+
+  describe('正常系 (ironclad)', () => {
+    it('1. ok: true を返す', () => {
+      const result = usecase.execute('ironclad', seed)
+      expect(result.ok).toBe(true)
+    })
+
+    it('2. player.id === "ironclad"', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.id).toBe('ironclad')
+    })
+
+    it('3. player.name === "Ironclad"', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.name).toBe('Ironclad')
+    })
+
+    it('4. player.health.current === 80 かつ player.health.max === 80', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.health.current).toBe(80)
+      expect(result.value.player.health.max).toBe(80)
+    })
+
+    it('5. player.energy.current === 3 かつ player.energy.max === 3', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.energy.current).toBe(3)
+      expect(result.value.player.energy.max).toBe(3)
+    })
+
+    it('6. player.gold.amount === 99', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.gold.amount).toBe(99)
+    })
+
+    it('7. player.block.value === 0', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.block.value).toBe(0)
+    })
+
+    it('8. player.deck.length === 10 (strike_r x5, defend_r x4, bash x1)', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.deck.length).toBe(10)
+    })
+
+    it('9. デッキに strike_r が5枚含まれる', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      const strikeCount = result.value.player.deck.filter((c) => c.id === 'strike_r').length
+      expect(strikeCount).toBe(5)
+    })
+
+    it('10. デッキに defend_r が4枚含まれる', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      const defendCount = result.value.player.deck.filter((c) => c.id === 'defend_r').length
+      expect(defendCount).toBe(4)
+    })
+
+    it('11. デッキに bash が1枚含まれる', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      const bashCount = result.value.player.deck.filter((c) => c.id === 'bash').length
+      expect(bashCount).toBe(1)
+    })
+
+    it('12. player.hand が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.hand).toEqual([])
+    })
+
+    it('13. player.discardPile が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.discardPile).toEqual([])
+    })
+
+    it('14. player.exhaustPile が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.exhaustPile).toEqual([])
+    })
+
+    it('15. player.relics が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.relics).toEqual([])
+    })
+
+    it('16. player.powers が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.powers).toEqual([])
+    })
+
+    it('17. player.statusEffects が空配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.statusEffects).toEqual([])
+    })
+
+    it('18. player.potions が [null, null, null]', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.potions).toEqual([null, null, null])
+    })
+
+    it('19. player.maxPotionSlots === 3', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.player.maxPotionSlots).toBe(3)
+    })
+
+    it('20. map が MapNode[][] 型の配列', () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(Array.isArray(result.value.map)).toBe(true)
+      expect(Array.isArray(result.value.map[0])).toBe(true)
+    })
+
+    it(`21. map.length === ${MAP_FLOORS_PER_ACT} (MAP_FLOORS_PER_ACT)`, () => {
+      const result = usecase.execute('ironclad', seed)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.map.length).toBe(MAP_FLOORS_PER_ACT)
+    })
+  })
+
+  describe('異常系', () => {
+    it('22. 未知のcharacterId ("silent") で err("unknown character") を返す', () => {
+      const result = usecase.execute('silent', seed)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('unknown character')
+    })
+
+    it('22b. 空文字列 characterId で err("unknown character") を返す', () => {
+      const result = usecase.execute('', seed)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('unknown character')
+    })
+
+    it('23. findById("strike_r") が undefined の場合、err を返す', () => {
+      const repoWithMissingStrike = buildCardRepo({ strike_r: undefined })
+      const uc = new StartRunUseCase(repoWithMissingStrike)
+      const result = uc.execute('ironclad', seed)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('Card not found: strike_r')
+    })
+
+    it('24. findById("defend_r") が undefined の場合、err を返す', () => {
+      const repoWithMissingDefend = buildCardRepo({ defend_r: undefined })
+      const uc = new StartRunUseCase(repoWithMissingDefend)
+      const result = uc.execute('ironclad', seed)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('Card not found: defend_r')
+    })
+
+    it('25. findById("bash") が undefined の場合、err を返す', () => {
+      const repoWithMissingBash = buildCardRepo({ bash: undefined })
+      const uc = new StartRunUseCase(repoWithMissingBash)
+      const result = uc.execute('ironclad', seed)
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('Card not found: bash')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **T59**: 手動DIコンテナ `createContainer(seed: Seed)` を実装。全インフラ実装をワイヤリング
- **T42**: `StartRunUseCase.execute(characterId, seed)` を TDD で実装。Ironclad 初期ラン状態（デッキ・マップ・Player）を `Result<T, E>` 型で返す
- `shared/constants.ts` に `IRONCLAD_STARTING_HP` / `IRONCLAD_STARTING_DECK` を追加（#111 で CharacterRepository に移行予定）

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npx vitest run` — 197 tests passed（26 テストが T42 新規追加）
- [x] TDD サイクル実施（RED → GREEN → IMPROVE）
- [x] typescript-reviewer レビュー実施・指摘対応済み
- [x] architect レビュー実施・指摘対応済み

## 将来対応

- CharacterRepository 導入（#111）時に `IRONCLAD_STARTING_HP` / `IRONCLAD_STARTING_DECK` を constants.ts から移行し、`StartRunUseCase` の characterId 決め打ち分岐を撤廃する

Closes #59
Closes #42