### PR TITLE
feat: T52 EventBus（Phaser↔React通信）

### DIFF
--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -30,8 +30,8 @@ export type EventMap = {
 
 // --- EventBus ---
 
-type Handler<T> = (payload: T) => void
-type Unsubscribe = () => void
+export type Handler<T> = (payload: T) => void
+export type Unsubscribe = () => void
 
 export class EventBusImpl {
   // TypeScript cannot infer a unified Map value type for discriminated generics.
@@ -57,6 +57,14 @@ export class EventBusImpl {
     }
     set.add(handler)
     return () => this.off(event, handler)
+  }
+
+  once<K extends keyof EventMap>(event: K, handler: Handler<EventMap[K]>): Unsubscribe {
+    const wrapper = (payload: EventMap[K]) => {
+      handler(payload)
+      this.off(event, wrapper)
+    }
+    return this.on(event, wrapper)
   }
 
   off<K extends keyof EventMap>(event: K, handler: Handler<EventMap[K]>): void {

--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -1,0 +1,72 @@
+import type { CardId, EnemyId } from '../../shared/types'
+
+// --- Event payload types ---
+
+export type PlayCardPayload = {
+  readonly cardId: CardId
+  readonly targetIndex?: number
+}
+
+export type AnimationCompletePayload = {
+  readonly animationKey: string
+}
+
+export type CombatStartPayload = {
+  readonly enemyId: EnemyId
+}
+
+export type CombatEndPayload = {
+  readonly playerWon: boolean
+}
+
+// --- Event map ---
+
+export type EventMap = {
+  playCard: PlayCardPayload
+  animationComplete: AnimationCompletePayload
+  combatStart: CombatStartPayload
+  combatEnd: CombatEndPayload
+}
+
+// --- EventBus ---
+
+type Handler<T> = (payload: T) => void
+type Unsubscribe = () => void
+
+export class EventBusImpl {
+  // TypeScript cannot infer a unified Map value type for discriminated generics.
+  // The public API (on/off/emit) is fully type-safe via K extends keyof EventMap.
+  // The `any` is intentional and confined to this private implementation detail.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly handlers = new Map<keyof EventMap, Set<Handler<any>>>()
+
+  emit<K extends keyof EventMap>(event: K, payload: EventMap[K]): void {
+    const set = this.handlers.get(event)
+    if (set === undefined) return
+    // Snapshot before iteration so that handlers calling off() during emit are safe.
+    for (const handler of [...set]) {
+      handler(payload)
+    }
+  }
+
+  on<K extends keyof EventMap>(event: K, handler: Handler<EventMap[K]>): Unsubscribe {
+    let set = this.handlers.get(event)
+    if (set === undefined) {
+      set = new Set()
+      this.handlers.set(event, set)
+    }
+    set.add(handler)
+    return () => this.off(event, handler)
+  }
+
+  off<K extends keyof EventMap>(event: K, handler: Handler<EventMap[K]>): void {
+    const set = this.handlers.get(event)
+    if (set === undefined) return
+    set.delete(handler)
+    if (set.size === 0) {
+      this.handlers.delete(event)
+    }
+  }
+}
+
+export const EventBus = new EventBusImpl()


### PR DESCRIPTION
Closes #52

## 概要
PhaserシーンとReactコンポーネント間を疎結合にするイベントバスを実装。

## 変更点
- `src/presentation/phaser/EventBus.ts` 新規作成
- 型安全な `EventMap` 定義（playCard / animationComplete / combatStart / combatEnd）
- `on` が unsubscribe 関数を返すことでメモリリークを防ぐ設計
- `once` メソッド追加（初回発火後に自動解除、発火前キャンセル可）
- emit 中の off 呼び出しを安全にするスナップショット処理
- `Handler<T>` / `Unsubscribe` を export

## テスト計画
- [ ] typecheck / lint 通過確認（CI）
- [ ] T53 PhaserGame 実装時に EventBus の動作を統合確認