### PR TITLE
fix: T52 EventBus イベント名を設計方針コメントに合わせて修正

### DIFF
--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -1,21 +1,26 @@
-import type { CardId, EnemyId } from '../../shared/types'
+import type { CardId, EnemyId, Target } from '../../shared/types'
 
 // --- Event payload types ---
 
 // React → Phaser: card animation instruction queued in Phaser
 export type PlayCardAnimationPayload = {
   readonly cardId: CardId
-  readonly targetId: EnemyId | string
+  readonly target: Target
+  // TODO: Narrow animationType to a string literal union once animation types are finalised.
+  // Tracked in: #66 CombatScene（戦闘アニメーションシーン）
   readonly animationType: string
 }
 
 // React → Phaser: combat effect request (damage flash, block, etc.)
 export type CombatEffectRequestPayload = {
+  // TODO: Narrow effectType to a string literal union once effect types are finalised.
+  // Tracked in: #66 CombatScene（戦闘アニメーションシーン）
   readonly effectType: string
-  readonly targetId: EnemyId | string
+  readonly target: Target
 }
 
 // Phaser internal: card animation completed (for queue management)
+/** @internal Used by Phaser scenes only. React components must not subscribe to this event. */
 export type CardAnimationCompletePayload = {
   readonly cardId: CardId
 }
@@ -41,7 +46,7 @@ export type EventMap = {
   playCardAnimation: PlayCardAnimationPayload
   // React → Phaser: request a combat effect (damage, block, etc.)
   combatEffectRequest: CombatEffectRequestPayload
-  // Phaser internal: notifies that a card animation finished
+  /** @internal Phaser internal: notifies that a card animation finished. Do not use in React. */
   cardAnimationComplete: CardAnimationCompletePayload
   // Scene lifecycle
   combatStart: CombatStartPayload
@@ -79,6 +84,11 @@ export class EventBusImpl {
     return () => this.off(event, handler)
   }
 
+  /**
+   * Subscribe for a single invocation. The handler is automatically removed after the first call.
+   * Cancel before firing via the returned Unsubscribe function.
+   * Do NOT call off(event, handler) directly — the internal wrapper reference differs from handler.
+   */
   once<K extends keyof EventMap>(event: K, handler: Handler<EventMap[K]>): Unsubscribe {
     const wrapper = (payload: EventMap[K]) => {
       handler(payload)
@@ -94,6 +104,11 @@ export class EventBusImpl {
     if (set.size === 0) {
       this.handlers.delete(event)
     }
+  }
+
+  /** Remove all handlers. Intended for test teardown to prevent cross-test leaks. */
+  clear(): void {
+    this.handlers.clear()
   }
 }
 

--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -2,15 +2,25 @@ import type { CardId, EnemyId } from '../../shared/types'
 
 // --- Event payload types ---
 
-export type PlayCardPayload = {
+// React → Phaser: card animation instruction queued in Phaser
+export type PlayCardAnimationPayload = {
   readonly cardId: CardId
-  readonly targetIndex?: number
+  readonly targetId: EnemyId | string
+  readonly animationType: string
 }
 
-export type AnimationCompletePayload = {
-  readonly animationKey: string
+// React → Phaser: combat effect request (damage flash, block, etc.)
+export type CombatEffectRequestPayload = {
+  readonly effectType: string
+  readonly targetId: EnemyId | string
 }
 
+// Phaser internal: card animation completed (for queue management)
+export type CardAnimationCompletePayload = {
+  readonly cardId: CardId
+}
+
+// React ↔ Phaser: combat scene lifecycle
 export type CombatStartPayload = {
   readonly enemyId: EnemyId
 }
@@ -20,10 +30,20 @@ export type CombatEndPayload = {
 }
 
 // --- Event map ---
+//
+// Design: 策A（カード操作=React、アニメーション=Phaser）
+//   React → Phaser : playCardAnimation, combatEffectRequest
+//   Phaser internal: cardAnimationComplete（queue management; not used for VM input control）
+//   React ↔ Phaser : combatStart, combatEnd（scene lifecycle）
 
 export type EventMap = {
-  playCard: PlayCardPayload
-  animationComplete: AnimationCompletePayload
+  // React → Phaser: play card animation with type info
+  playCardAnimation: PlayCardAnimationPayload
+  // React → Phaser: request a combat effect (damage, block, etc.)
+  combatEffectRequest: CombatEffectRequestPayload
+  // Phaser internal: notifies that a card animation finished
+  cardAnimationComplete: CardAnimationCompletePayload
+  // Scene lifecycle
   combatStart: CombatStartPayload
   combatEnd: CombatEndPayload
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -13,6 +13,15 @@ export type StatusEffectId = string & { readonly _brand: 'StatusEffectId' }
 // PowerId: 筋力・アーティファクト等のパワー識別子（T16）
 export type PowerId = string & { readonly _brand: 'PowerId' }
 
+// --- Target (discriminated union) ---
+// Represents the runtime target of an animation or effect.
+// Distinct from TargetType (domain enum for card metadata) — this is a concrete runtime value.
+// Used in EventBus payloads (presentation) and may be used in EffectDef (domain) in the future.
+export type Target =
+  | { readonly kind: 'enemy'; readonly id: EnemyId }
+  | { readonly kind: 'player' }
+  | { readonly kind: 'all' }
+
 // --- Effect definition ---
 // Data structure representing a card effect as stored in JSON/Card entity.
 // Consumed by EffectFactory (application layer) to build executable Effect objects.


### PR DESCRIPTION
## 概要
#52 のissueコメント（策A設計方針）がT52実装時に反映されていなかったため修正。

## 変更内容

### イベント名の修正

| 旧イベント名 | 新イベント名 | 変更理由 |
|------------|------------|---------|
| `playCard` | `playCardAnimation` | animationTypeが必須（Phaserはどのアニメーションを再生するか知る必要がある） |
| `animationComplete` | `cardAnimationComplete` | Phaserキュー管理にはカード単位の完了通知が必要 |
| （未定義） | `combatEffectRequest` | ダメージ・ブロック等のエフェクトをPhaserに依頼する口がなかった |

`combatStart` / `combatEnd` はシーンライフサイクル管理として引き続き維持。

### Target 判別可能ユニオン導入（`src/shared/types/index.ts`）

`EnemyId | string`（ブランド型保護ゼロ）を廃止し、判別可能ユニオンを導入：

```typescript
type Target =
  | { readonly kind: 'enemy'; readonly id: EnemyId }
  | { readonly kind: 'player' }
  | { readonly kind: 'all' }
```

- switch 文の網羅性チェックが保証される
- 既存の `Result<T,E>` パターンと一貫
- 将来 `EffectDef.target` への転用が容易

### その他改善

- `clear()` メソッド追加（テスト間ハンドラリーク防止）
- `once()` に `@internal` / キャンセル方法のJSDoc追加
- `cardAnimationComplete` に `@internal` タグ追加
- `animationType` / `effectType` の TODO コメントを #66 に紐づけ

## 参考
- #52 issueコメント: 設計方針決定: 策A（カード操作=React、アニメーション=Phaser）
- #66 にて `animationType` / `effectType` のリテラルユニオン化を追跡