### PR TITLE
feat: T53 PhaserGame（Phaser初期化）

### DIFF
--- a/src/presentation/phaser/PhaserGame.tsx
+++ b/src/presentation/phaser/PhaserGame.tsx
@@ -1,0 +1,61 @@
+import Phaser from 'phaser'
+import React, { useEffect, useRef } from 'react'
+
+import { PHASER_BACKGROUND_COLOR, PHASER_CANVAS_Z_INDEX } from '../../shared/constants'
+
+// z-index structure:
+//   z-index: 100 — dragging cards (React)
+//   z-index: 10  — normal cards / UI overlay (React)
+//   z-index: 5   — Phaser canvas (pointer-events: none)
+//   z-index: 0   — background (React)
+
+// Props intentionally restrict width/height to number (px only).
+// Phaser.GameConfig accepts string (e.g. "100%") but relative sizing
+// is not required in this project and would complicate canvas style management.
+type Props = {
+  scenes: Phaser.Types.Scenes.SceneType[]
+  width?: number
+  height?: number
+}
+
+export function PhaserGame({ scenes, width = 1280, height = 720 }: Props): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Stabilize scenes and canvas size so the effect runs only once on mount.
+  // Callers must not rely on hot-swapping scenes or resizing after mount.
+  const scenesRef = useRef(scenes)
+  const widthRef = useRef(width)
+  const heightRef = useRef(height)
+
+  useEffect(() => {
+    if (containerRef.current === null) return
+
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      width: widthRef.current,
+      height: heightRef.current,
+      parent: containerRef.current,
+      backgroundColor: PHASER_BACKGROUND_COLOR,
+      // Card operations are handled by React; disable Phaser input on canvas.
+      input: {
+        mouse: { preventDefaultWheel: false },
+        touch: false,
+      },
+      scene: scenesRef.current,
+    }
+
+    const game = new Phaser.Game(config)
+
+    // Ensure React UI events pass through the canvas.
+    game.canvas.style.pointerEvents = 'none'
+    // PHASER_CANVAS_Z_INDEX is the CSS z-index value (number) for the Phaser canvas layer.
+    game.canvas.style.zIndex = String(PHASER_CANVAS_Z_INDEX)
+
+    return () => {
+      // destroy(true) removes the canvas from the DOM asynchronously on the next game loop tick.
+      // No additional removeChild needed; Phaser handles DOM cleanup when removeCanvas=true.
+      game.destroy(true)
+    }
+  }, [])
+
+  return <div ref={containerRef} style={{ position: 'relative', width, height }} />
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -52,3 +52,7 @@ export const SHOP_REMOVE_COST = 75
 
 // Rest Site
 export const REST_HEAL_PERCENT = 0.3
+
+// Phaser
+export const PHASER_BACKGROUND_COLOR = '#1a1a2e'
+export const PHASER_CANVAS_Z_INDEX = 5


### PR DESCRIPTION
Closes #53

## 概要
PhaserをReactコンポーネントとして内包する初期化ラッパーを実装。

## 変更点
- `src/presentation/phaser/PhaserGame.tsx` 新規作成
- `src/shared/constants.ts` に `PHASER_BACKGROUND_COLOR` / `PHASER_CANVAS_Z_INDEX` 追加
- pointer-events: none でReact UIへのイベント通過を保証（策A設計方針）
- z-index: 5 でPhaserキャンバスをReact UIの下に配置
- `useRef` で scenes/width/height を初回値固定（マウント後の再生成を防止）
- destroy(true) でPhaser側にDOM除去を委譲

## テスト計画
- [ ] typecheck / lint 通過確認（CI）
- [ ] T54 / T67 実装時に PhaserGame の動作を統合確認