### PR TITLE
feat: T67 MapScene（マップ描画シーン）

### DIFF
--- a/src/domain/enums/NodeType.ts
+++ b/src/domain/enums/NodeType.ts
@@ -1,22 +1,5 @@
 /**
- * マップノード種別列挙型
- *
- * - Combat : 通常戦闘
- * - Elite  : エリート戦闘（強敵・高報酬）
- * - Event  : イベント（選択肢あり）
- * - Shop   : ショップ（カード・レリック購入）
- * - Rest   : 休憩所（HP回復またはカード強化）
- * - Boss   : ボス戦闘（Act末尾）
- *
- * 外部依存ゼロ（import不要）
+ * NodeType は shared/types に移動しました。
+ * domain 層の既存 import を壊さないよう re-export しています。
  */
-export const NodeType = {
-  Combat: 'Combat',
-  Elite: 'Elite',
-  Event: 'Event',
-  Shop: 'Shop',
-  Rest: 'Rest',
-  Boss: 'Boss',
-} as const
-
-export type NodeType = (typeof NodeType)[keyof typeof NodeType]
+export { NodeType } from '../../shared/types/NodeType'

--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -1,4 +1,4 @@
-import type { CardId, EnemyId, Target } from '../../shared/types'
+import type { CardId, EnemyId, NodeId, Target } from '../../shared/types'
 
 // --- Event payload types ---
 
@@ -34,12 +34,38 @@ export type CombatEndPayload = {
   readonly playerWon: boolean
 }
 
+// React → Phaser: map node data for rendering.
+// Includes column position (index within the floor) alongside MapNode fields,
+// since MapNode itself does not carry layout information.
+export type MapNodeRenderData = {
+  readonly id: NodeId
+  // NodeType value as a string to avoid importing domain enums into the presentation bus.
+  readonly type: string
+  readonly floor: number
+  readonly column: number
+  readonly connections: readonly NodeId[]
+  readonly visited: boolean
+}
+
+// React → Phaser: full map state update for MapScene to render.
+export type MapUpdatePayload = {
+  readonly nodes: readonly MapNodeRenderData[]
+  readonly currentNodeId: NodeId | null
+  readonly selectableNodeIds: readonly NodeId[]
+}
+
+// React → Phaser: notify MapScene which node the player selected (for visual highlight).
+export type NodeSelectedPayload = {
+  readonly nodeId: NodeId
+}
+
 // --- Event map ---
 //
 // Design: 策A（カード操作=React、アニメーション=Phaser）
 //   React → Phaser : playCardAnimation, combatEffectRequest
 //   Phaser internal: cardAnimationComplete（queue management; not used for VM input control）
 //   React ↔ Phaser : combatStart, combatEnd（scene lifecycle）
+//   React → Phaser : mapUpdate, nodeSelected（map scene rendering）
 
 export type EventMap = {
   // React → Phaser: play card animation with type info
@@ -51,6 +77,9 @@ export type EventMap = {
   // Scene lifecycle
   combatStart: CombatStartPayload
   combatEnd: CombatEndPayload
+  // Map scene rendering
+  mapUpdate: MapUpdatePayload
+  nodeSelected: NodeSelectedPayload
 }
 
 // --- EventBus ---

--- a/src/presentation/phaser/EventBus.ts
+++ b/src/presentation/phaser/EventBus.ts
@@ -1,4 +1,4 @@
-import type { CardId, EnemyId, NodeId, Target } from '../../shared/types'
+import type { CardId, EnemyId, NodeId, NodeType, Target } from '../../shared/types'
 
 // --- Event payload types ---
 
@@ -39,8 +39,8 @@ export type CombatEndPayload = {
 // since MapNode itself does not carry layout information.
 export type MapNodeRenderData = {
   readonly id: NodeId
-  // NodeType value as a string to avoid importing domain enums into the presentation bus.
-  readonly type: string
+  // NodeType is defined in shared/types (no domain dependency) so it can be used safely here.
+  readonly type: NodeType
   readonly floor: number
   readonly column: number
   readonly connections: readonly NodeId[]

--- a/src/presentation/phaser/scenes/MapScene.ts
+++ b/src/presentation/phaser/scenes/MapScene.ts
@@ -6,6 +6,7 @@ import {
   type MapUpdatePayload,
   type Unsubscribe,
 } from '../EventBus'
+import { NodeType } from '../../../shared/types'
 import type { NodeId } from '../../../shared/types'
 
 /**
@@ -29,27 +30,24 @@ const NODE_RADIUS = 18
 const NODE_LABEL_OFFSET_Y = NODE_RADIUS + 8
 
 // ---- ノード種別ごとの表示色 ----
-// NodeType の string 値をキーとする。EventBus ペイロードは string で渡される。
-// TODO: NodeType を shared/types に移動して型安全性を高めることを検討する。
-// Tracked in: #67 MapScene（マップ描画シーン）
-const NODE_FILL_COLOR: Record<string, number> = {
-  Combat: 0x888888,
-  Elite: 0xaa44cc,
-  Event: 0x4488cc,
-  Shop: 0xddaa00,
-  Rest: 0x44aa66,
-  Boss: 0xcc3333,
+// NodeType は shared/types で定義されているため、型安全に Record のキーとして使用できる。
+const NODE_FILL_COLOR: Record<NodeType, number> = {
+  [NodeType.Combat]: 0x888888,
+  [NodeType.Elite]: 0xaa44cc,
+  [NodeType.Event]: 0x4488cc,
+  [NodeType.Shop]: 0xddaa00,
+  [NodeType.Rest]: 0x44aa66,
+  [NodeType.Boss]: 0xcc3333,
 }
-const NODE_FILL_COLOR_FALLBACK = 0x666666
 
 // ---- ノード種別ごとの略称ラベル ----
-const NODE_TYPE_LABEL: Record<string, string> = {
-  Combat: 'CMB',
-  Elite: 'ELT',
-  Event: 'EVT',
-  Shop: 'SHP',
-  Rest: 'RST',
-  Boss: 'BSS',
+const NODE_TYPE_LABEL: Record<NodeType, string> = {
+  [NodeType.Combat]: 'CMB',
+  [NodeType.Elite]: 'ELT',
+  [NodeType.Event]: 'EVT',
+  [NodeType.Shop]: 'SHP',
+  [NodeType.Rest]: 'RST',
+  [NodeType.Boss]: 'BSS',
 }
 
 // ---- ビジュアル定数 ----
@@ -184,7 +182,7 @@ export class MapScene extends Phaser.Scene {
       const isSelectable = selectableSet.has(node.id)
       const isActive = node.visited || isCurrent || isSelectable
       const fillAlpha = isActive ? ALPHA_ACTIVE : ALPHA_INACTIVE
-      const fillColor = NODE_FILL_COLOR[node.type] ?? NODE_FILL_COLOR_FALLBACK
+      const fillColor = NODE_FILL_COLOR[node.type]
 
       // Outer ring for current / selected node
       if (isCurrent || isSelected) {
@@ -204,7 +202,7 @@ export class MapScene extends Phaser.Scene {
       this.nodeGraphics?.fillCircle(pos.x, pos.y, NODE_RADIUS)
 
       // Node type label (Text object lifetime managed by labelGroup)
-      const labelText = NODE_TYPE_LABEL[node.type] ?? node.type
+      const labelText = NODE_TYPE_LABEL[node.type]
       const label = this.add
         .text(pos.x, pos.y + NODE_LABEL_OFFSET_Y, labelText, {
           fontSize: '10px',

--- a/src/presentation/phaser/scenes/MapScene.ts
+++ b/src/presentation/phaser/scenes/MapScene.ts
@@ -1,0 +1,250 @@
+import Phaser from 'phaser'
+
+import {
+  EventBus,
+  type MapNodeRenderData,
+  type MapUpdatePayload,
+  type Unsubscribe,
+} from '../EventBus'
+import type { NodeId } from '../../../shared/types'
+
+/**
+ * MapScene — マップ描画シーン
+ *
+ * EventBus 経由で React（useMapViewModel）から受け取ったマップデータを Canvas に描画する。
+ * ゲームロジックは持たない（純粋な描画担当）。
+ *
+ * 参照可能な層: presentation のみ（domain/application/infrastructure は直接 import 禁止）
+ */
+
+// ---- レイアウト定数 ----
+const MAP_ORIGIN_X = 240
+const MAP_ORIGIN_Y = 60
+const MAP_HEIGHT_PX = 580
+const MAX_COLUMNS = 7
+// 横方向のノード間隔: 利用可能幅 800px を MAX_COLUMNS+1 等分
+const COL_SPACING = 800 / (MAX_COLUMNS + 1)
+
+const NODE_RADIUS = 18
+const NODE_LABEL_OFFSET_Y = NODE_RADIUS + 8
+
+// ---- ノード種別ごとの表示色 ----
+// NodeType の string 値をキーとする。EventBus ペイロードは string で渡される。
+// TODO: NodeType を shared/types に移動して型安全性を高めることを検討する。
+// Tracked in: #67 MapScene（マップ描画シーン）
+const NODE_FILL_COLOR: Record<string, number> = {
+  Combat: 0x888888,
+  Elite: 0xaa44cc,
+  Event: 0x4488cc,
+  Shop: 0xddaa00,
+  Rest: 0x44aa66,
+  Boss: 0xcc3333,
+}
+const NODE_FILL_COLOR_FALLBACK = 0x666666
+
+// ---- ノード種別ごとの略称ラベル ----
+const NODE_TYPE_LABEL: Record<string, string> = {
+  Combat: 'CMB',
+  Elite: 'ELT',
+  Event: 'EVT',
+  Shop: 'SHP',
+  Rest: 'RST',
+  Boss: 'BSS',
+}
+
+// ---- ビジュアル定数 ----
+const ALPHA_ACTIVE = 1.0
+const ALPHA_INACTIVE = 0.35
+const PATH_COLOR = 0x666666
+const PATH_ALPHA_VISITED = 0.8
+const PATH_ALPHA_UNVISITED = 0.3
+const CURRENT_RING_COLOR = 0xffffff
+const SELECTED_RING_COLOR = 0xffff00
+const SELECTABLE_RING_COLOR = 0x88ff88
+const RING_STROKE_WIDTH = 3
+const RING_RADIUS_OUTER = NODE_RADIUS + 6
+const RING_RADIUS_SELECTABLE = NODE_RADIUS + 3
+
+export class MapScene extends Phaser.Scene {
+  private pathGraphics: Phaser.GameObjects.Graphics | null = null
+  private nodeGraphics: Phaser.GameObjects.Graphics | null = null
+  /** Text labels for node types; cleared and recreated on each render. */
+  private labelGroup: Phaser.GameObjects.Group | null = null
+
+  private currentPayload: MapUpdatePayload | null = null
+  private selectedNodeId: NodeId | null = null
+
+  private unsubMapUpdate: Unsubscribe | null = null
+  private unsubNodeSelected: Unsubscribe | null = null
+
+  constructor() {
+    super({ key: 'MapScene' })
+  }
+
+  create(): void {
+    // Draw order: paths (bottom) → nodes → labels (top)
+    this.pathGraphics = this.add.graphics()
+    this.nodeGraphics = this.add.graphics()
+    this.labelGroup = this.add.group()
+
+    this.unsubMapUpdate = EventBus.on('mapUpdate', (payload) => {
+      // Guard: discard stale events delivered after the scene was stopped or destroyed.
+      if (!this.scene.isActive('MapScene')) return
+      this.currentPayload = payload
+      // Reset selection when new map data arrives; the previous NodeId may not exist in the
+      // new payload (e.g. floor transition) and would cause a stale highlight.
+      this.selectedNodeId = null
+      this.renderMap()
+    })
+
+    this.unsubNodeSelected = EventBus.on('nodeSelected', (payload) => {
+      if (!this.scene.isActive('MapScene')) return
+      this.selectedNodeId = payload.nodeId
+      this.renderMap()
+    })
+  }
+
+  /**
+   * Called by Phaser when the scene is stopped (scene.stop / scene.sleep).
+   * Removes EventBus subscriptions so stale handlers do not fire.
+   * Note: Phaser.Scene does not declare this method in its TypeScript types;
+   * it is invoked via Phaser's internal event system on the 'shutdown' event.
+   */
+  shutdown(): void {
+    this.cleanupSubscriptions()
+    this.cleanupGraphics()
+  }
+
+  /**
+   * Called by Phaser when the scene is removed from the SceneManager.
+   * Mirrors shutdown() to ensure cleanup when the scene is destroyed rather than stopped.
+   * Note: Phaser.Scene does not declare destroy() in its TypeScript types;
+   * it is invoked via Phaser's internal event system on the 'destroy' event.
+   */
+  destroy(): void {
+    this.cleanupSubscriptions()
+    this.cleanupGraphics()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private rendering helpers
+  // ---------------------------------------------------------------------------
+
+  private renderMap(): void {
+    if (this.currentPayload === null) return
+
+    this.pathGraphics?.clear()
+    this.nodeGraphics?.clear()
+    // Destroy existing label Text objects before recreating them.
+    this.labelGroup?.clear(true, true)
+
+    const { nodes, currentNodeId, selectableNodeIds } = this.currentPayload
+    const nodeMap = new Map<NodeId, MapNodeRenderData>(nodes.map((n) => [n.id, n]))
+    const selectableSet = new Set<NodeId>(selectableNodeIds)
+    const maxFloor = nodes.reduce((max, n) => Math.max(max, n.floor), 0)
+
+    // Connections in MapNodeRenderData are directed (parent → child), matching
+    // the MapGenerator output. Drawing each node's outgoing edges once is sufficient;
+    // iterating all nodes produces no duplicate lines under this invariant.
+    this.drawPaths(nodes, nodeMap, maxFloor)
+    this.drawNodes(nodes, currentNodeId, selectableSet, maxFloor)
+  }
+
+  private drawPaths(
+    nodes: readonly MapNodeRenderData[],
+    nodeMap: Map<NodeId, MapNodeRenderData>,
+    maxFloor: number,
+  ): void {
+    for (const node of nodes) {
+      const from = this.nodePosition(node.column, node.floor, maxFloor)
+      for (const connId of node.connections) {
+        const connNode = nodeMap.get(connId)
+        if (connNode === undefined) continue
+        const to = this.nodePosition(connNode.column, connNode.floor, maxFloor)
+        const alpha = node.visited ? PATH_ALPHA_VISITED : PATH_ALPHA_UNVISITED
+        this.pathGraphics?.lineStyle(2, PATH_COLOR, alpha)
+        this.pathGraphics?.beginPath()
+        this.pathGraphics?.moveTo(from.x, from.y)
+        this.pathGraphics?.lineTo(to.x, to.y)
+        this.pathGraphics?.strokePath()
+      }
+    }
+  }
+
+  private drawNodes(
+    nodes: readonly MapNodeRenderData[],
+    currentNodeId: NodeId | null,
+    selectableSet: Set<NodeId>,
+    maxFloor: number,
+  ): void {
+    for (const node of nodes) {
+      const pos = this.nodePosition(node.column, node.floor, maxFloor)
+      const isCurrent = node.id === currentNodeId
+      const isSelected = node.id === this.selectedNodeId
+      const isSelectable = selectableSet.has(node.id)
+      const isActive = node.visited || isCurrent || isSelectable
+      const fillAlpha = isActive ? ALPHA_ACTIVE : ALPHA_INACTIVE
+      const fillColor = NODE_FILL_COLOR[node.type] ?? NODE_FILL_COLOR_FALLBACK
+
+      // Outer ring for current / selected node
+      if (isCurrent || isSelected) {
+        const ringColor = isCurrent ? CURRENT_RING_COLOR : SELECTED_RING_COLOR
+        this.nodeGraphics?.lineStyle(RING_STROKE_WIDTH, ringColor, 1)
+        this.nodeGraphics?.strokeCircle(pos.x, pos.y, RING_RADIUS_OUTER)
+      }
+
+      // Subtle ring for selectable (reachable next) nodes
+      if (isSelectable && !isCurrent) {
+        this.nodeGraphics?.lineStyle(2, SELECTABLE_RING_COLOR, 0.7)
+        this.nodeGraphics?.strokeCircle(pos.x, pos.y, RING_RADIUS_SELECTABLE)
+      }
+
+      // Node body
+      this.nodeGraphics?.fillStyle(fillColor, fillAlpha)
+      this.nodeGraphics?.fillCircle(pos.x, pos.y, NODE_RADIUS)
+
+      // Node type label (Text object lifetime managed by labelGroup)
+      const labelText = NODE_TYPE_LABEL[node.type] ?? node.type
+      const label = this.add
+        .text(pos.x, pos.y + NODE_LABEL_OFFSET_Y, labelText, {
+          fontSize: '10px',
+          color: '#cccccc',
+        })
+        .setOrigin(0.5, 0)
+        .setAlpha(fillAlpha)
+      this.labelGroup?.add(label)
+    }
+  }
+
+  /**
+   * ノードのCanvas座標を計算する。
+   * floor 0 が画面下、ボス（最大floor）が画面上になるよう配置する。
+   */
+  private nodePosition(
+    column: number,
+    floor: number,
+    maxFloor: number,
+  ): { readonly x: number; readonly y: number } {
+    const x = MAP_ORIGIN_X + COL_SPACING * (column + 1)
+    const floorRatio = maxFloor > 0 ? floor / maxFloor : 0
+    const y = MAP_ORIGIN_Y + MAP_HEIGHT_PX * (1 - floorRatio)
+    return { x, y }
+  }
+
+  private cleanupSubscriptions(): void {
+    this.unsubMapUpdate?.()
+    this.unsubNodeSelected?.()
+    this.unsubMapUpdate = null
+    this.unsubNodeSelected = null
+  }
+
+  private cleanupGraphics(): void {
+    this.pathGraphics?.destroy()
+    this.nodeGraphics?.destroy()
+    this.labelGroup?.clear(true, true)
+    this.labelGroup?.destroy()
+    this.pathGraphics = null
+    this.nodeGraphics = null
+    this.labelGroup = null
+  }
+}

--- a/src/shared/types/NodeType.ts
+++ b/src/shared/types/NodeType.ts
@@ -1,0 +1,22 @@
+/**
+ * マップノード種別列挙型
+ *
+ * - Combat : 通常戦闘
+ * - Elite  : エリート戦闘（強敵・高報酬）
+ * - Event  : イベント（選択肢あり）
+ * - Shop   : ショップ（カード・レリック購入）
+ * - Rest   : 休憩所（HP回復またはカード強化）
+ * - Boss   : ボス戦闘（Act末尾）
+ *
+ * 外部依存ゼロ。shared 層に配置することで presentation/domain 双方から型安全に参照できる。
+ */
+export const NodeType = {
+  Combat: 'Combat',
+  Elite: 'Elite',
+  Event: 'Event',
+  Shop: 'Shop',
+  Rest: 'Rest',
+  Boss: 'Boss',
+} as const
+
+export type NodeType = (typeof NodeType)[keyof typeof NodeType]

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -34,3 +34,4 @@ export type EffectDef = {
 // --- Re-exports ---
 export type { Result } from './Result'
 export { ok, err } from './Result'
+export { NodeType } from './NodeType'


### PR DESCRIPTION
## Summary
- `src/presentation/phaser/scenes/MapScene.ts` を新規作成
- `src/presentation/phaser/EventBus.ts` に `mapUpdate` / `nodeSelected` イベントと対応ペイロード型を追加
- `NodeType` を `src/domain/enums/` から `src/shared/types/` に移動し、`MapNodeRenderData.type` を型安全な `NodeType` に変更（`string` から昇格）
- `domain/enums/NodeType.ts` は既存 import との後方互換のため re-export のみに変更
- ノード種別色・略称ラベルを `Record<NodeType, ...>` で全列挙型を網羅的に定義
- `shutdown()` / `destroy()` で EventBus 購読解除と Graphics リソースを確実にクリーンアップ
- EventBus コールバックにシーンアクティブガードを追加（遷移後の stale イベントを防止）
- `mapUpdate` 受信時に `selectedNodeId` をリセット（フロア遷移後の不正ハイライトを防止）

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:run` 通過（250 tests）
- [x] typescript-reviewer レビュー実施済み（HIGH 3件・MEDIUM 1件修正済み）

Closes #67