### PR TITLE
feat: T46 SelectNodeUseCase（マップノード選択）

### DIFF
--- a/src/application/usecases/SelectNodeUseCase.ts
+++ b/src/application/usecases/SelectNodeUseCase.ts
@@ -1,0 +1,58 @@
+import type { MapNode } from '../../domain/entities/MapNode'
+import type { NodeId } from '../../shared/types'
+import { type Result, ok, err } from '../../shared/types'
+
+export type SelectNodeError = 'node_not_found' | 'not_accessible' | 'current_node_not_found'
+
+export interface SelectNodeParams {
+  readonly map: ReadonlyArray<ReadonlyArray<MapNode>>
+  readonly currentNodeId: NodeId | null
+  readonly targetNodeId: NodeId
+}
+
+/**
+ * マップノード選択ユースケース
+ *
+ * 指定ノードへの移動が可能かを検証し、可能であれば選択先ノードを返す。
+ *
+ * 検証ルール:
+ * - currentNodeId === null の場合: floor 0 のノードのみ選択可能（ゲーム開始時）
+ * - currentNodeId !== null の場合: currentNode.connections に含まれるノードのみ選択可能
+ *
+ * 参照してはいけない層: infrastructure, presentation
+ */
+export class SelectNodeUseCase {
+  execute(params: SelectNodeParams): Result<MapNode, SelectNodeError> {
+    const { map, currentNodeId, targetNodeId } = params
+
+    // 全ノードを検索
+    const targetNode = this.findNode(map, targetNodeId)
+    if (targetNode === undefined) return err('node_not_found')
+
+    if (currentNodeId === null) {
+      // ゲーム開始時: floor 0 のノードのみ選択可能
+      if (targetNode.floor !== 0) return err('not_accessible')
+      return ok(targetNode)
+    }
+
+    // 移動中: 接続ノードのみ選択可能
+    const currentNode = this.findNode(map, currentNodeId)
+    if (currentNode === undefined) return err('current_node_not_found')
+
+    if (!currentNode.connections.includes(targetNodeId)) return err('not_accessible')
+
+    return ok(targetNode)
+  }
+
+  private findNode(
+    map: ReadonlyArray<ReadonlyArray<MapNode>>,
+    nodeId: NodeId,
+  ): MapNode | undefined {
+    for (const floor of map) {
+      for (const node of floor) {
+        if (node.id === nodeId) return node
+      }
+    }
+    return undefined
+  }
+}

--- a/tests/application/usecases/SelectNodeUseCase.test.ts
+++ b/tests/application/usecases/SelectNodeUseCase.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { SelectNodeUseCase } from '../../../src/application/usecases/SelectNodeUseCase'
+import type { MapNode } from '../../../src/domain/entities/MapNode'
+import { NodeType } from '../../../src/shared/types'
+import type { NodeId } from '../../../src/shared/types'
+
+// --- Test helpers ---
+
+function makeNode(
+  id: string,
+  floor: number,
+  connections: string[] = [],
+  type: NodeType = NodeType.Combat,
+): MapNode {
+  return {
+    id: id as NodeId,
+    type,
+    floor,
+    connections: connections.map((c) => c as NodeId),
+    visited: false,
+  }
+}
+
+/**
+ * 2フロアのシンプルなマップ:
+ *   Floor 0: node-0 (Combat)
+ *   Floor 1: node-1 (Combat), node-2 (Elite)
+ *   node-0 → [node-1, node-2]
+ */
+const SIMPLE_MAP: MapNode[][] = [
+  [makeNode('node-0', 0, ['node-1', 'node-2'], NodeType.Combat)],
+  [makeNode('node-1', 1, [], NodeType.Combat), makeNode('node-2', 1, [], NodeType.Elite)],
+]
+
+const node0 = SIMPLE_MAP[0]![0]!
+const node1 = SIMPLE_MAP[1]![0]!
+const node2 = SIMPLE_MAP[1]![1]!
+
+// --- Tests ---
+
+describe('SelectNodeUseCase', () => {
+  const usecase = new SelectNodeUseCase()
+
+  describe('初回選択（currentNodeId === null）', () => {
+    it('1. floor 0 のノードを選択できる', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: null,
+        targetNodeId: node0.id,
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.id).toBe('node-0')
+    })
+
+    it('2. floor 0 以外のノードは選択不可 → not_accessible', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: null,
+        targetNodeId: node1.id,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('not_accessible')
+    })
+
+    it('3. 存在しないノードIDは node_not_found', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: null,
+        targetNodeId: 'non-existent' as NodeId,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('node_not_found')
+    })
+  })
+
+  describe('移動先選択（currentNodeId !== null）', () => {
+    it('4. 接続されているノードへ移動できる（node-0 → node-1）', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: node0.id,
+        targetNodeId: node1.id,
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.id).toBe('node-1')
+    })
+
+    it('5. 接続されているノードへ移動できる（node-0 → node-2）', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: node0.id,
+        targetNodeId: node2.id,
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.id).toBe('node-2')
+    })
+
+    it('6. 接続されていないノードへの移動は not_accessible', () => {
+      // node-1 は node-2 と接続されていない
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: node1.id,
+        targetNodeId: node2.id,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('not_accessible')
+    })
+
+    it('7. 存在しないcurrentNodeIdは current_node_not_found', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: 'ghost-node' as NodeId,
+        targetNodeId: node1.id,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('current_node_not_found')
+    })
+
+    it('8. 存在しないtargetNodeIdは node_not_found', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: node0.id,
+        targetNodeId: 'ghost-node' as NodeId,
+      })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('Expected error')
+      expect(result.error).toBe('node_not_found')
+    })
+  })
+
+  describe('戻り値の検証', () => {
+    it('9. 返却されるノードは targetNodeId と一致する', () => {
+      const result = usecase.execute({
+        map: SIMPLE_MAP,
+        currentNodeId: node0.id,
+        targetNodeId: node2.id,
+      })
+      if (!result.ok) throw new Error(result.error)
+      expect(result.value.id).toBe(node2.id)
+      expect(result.value.type).toBe(NodeType.Elite)
+      expect(result.value.floor).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## 概要

マップ上のノードを選択して移動する際の検証を行うユースケースを実装。

## 変更内容

- `src/application/usecases/SelectNodeUseCase.ts` 新規作成
- `tests/application/usecases/SelectNodeUseCase.test.ts` 新規作成（9テスト）

## 設計判断

- issueの暫定シグネチャ `execute(player, map, nodeId)` を更新: `Player` は不要（currentNodeIdはVMが管理）
- `SelectNodeError` を export（呼び出し元から型参照可能に）
- `map` パラメータを `ReadonlyArray<ReadonlyArray<MapNode>>` で不変性明示

## テスト計画

- [x] floor 0 の初回選択（currentNodeId === null）
- [x] 接続ノードへの移動
- [x] 非接続ノードへの移動拒否（not_accessible）
- [x] 存在しないノードIDの拒否（node_not_found / current_node_not_found）

Closes #46