### PR TITLE
feat: T55 useRunViewModel（ランVM）

### DIFF
--- a/src/presentation/viewmodels/useRunViewModel.ts
+++ b/src/presentation/viewmodels/useRunViewModel.ts
@@ -1,0 +1,73 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { castDraft } from 'immer'
+import type { Player } from '../../domain/entities/Player'
+import type { MapNode } from '../../domain/entities/MapNode'
+import { Seed } from '../../domain/value-objects/Seed'
+import { ScreenType } from '../../shared/types/ScreenType'
+import { createContainer } from '../../di/container'
+
+/**
+ * ランViewModel — ゲーム全体の状態を管理するZustandストア
+ *
+ * 責務:
+ * - 現在表示中の画面（currentScreen）
+ * - プレイヤー状態（player）・マップ状態（map）
+ * - ラン開始（startRun）・画面遷移（navigateTo）アクション
+ * - startRun失敗時のエラー状態（startRunError）
+ *
+ * 参照してはいけない層: infrastructure（DIコンテナ経由でのみアクセス）
+ */
+interface RunState {
+  readonly currentScreen: ScreenType
+  readonly player: Player | null
+  readonly map: MapNode[][] | null
+  /** startRun失敗時のエラーメッセージ。成功時・未実行時は null */
+  readonly startRunError: string | null
+  /** startRun実行中フラグ（二重起動防止） */
+  readonly isStarting: boolean
+  startRun: (characterId: string) => void
+  navigateTo: (screen: ScreenType) => void
+}
+
+export const useRunViewModel = create<RunState>()(
+  immer((set) => ({
+    currentScreen: ScreenType.Map,
+    player: null,
+    map: null,
+    startRunError: null,
+    isStarting: false,
+
+    startRun: (characterId: string) => {
+      set((draft) => {
+        if (draft.isStarting) return
+        draft.isStarting = true
+        draft.startRunError = null
+      })
+
+      const seed = Seed.generate()
+      const container = createContainer(seed)
+      const result = container.startRunUseCase.execute(characterId, seed)
+
+      if (result.ok) {
+        set((draft) => {
+          draft.player = castDraft(result.value.player)
+          draft.map = castDraft(result.value.map)
+          draft.currentScreen = ScreenType.Map
+          draft.isStarting = false
+        })
+      } else {
+        set((draft) => {
+          draft.startRunError = result.error
+          draft.isStarting = false
+        })
+      }
+    },
+
+    navigateTo: (screen: ScreenType) => {
+      set((draft) => {
+        draft.currentScreen = screen
+      })
+    },
+  })),
+)

--- a/src/shared/types/ScreenType.ts
+++ b/src/shared/types/ScreenType.ts
@@ -1,0 +1,18 @@
+/**
+ * 画面種別
+ *
+ * ゲーム内で遷移可能な画面の一覧。
+ * presentation 層と application 層の双方から型安全に参照できるよう shared に配置。
+ *
+ * 外部依存ゼロ。
+ */
+export const ScreenType = {
+  Map: 'Map',
+  Combat: 'Combat',
+  Reward: 'Reward',
+  Shop: 'Shop',
+  Rest: 'Rest',
+  Event: 'Event',
+} as const
+
+export type ScreenType = (typeof ScreenType)[keyof typeof ScreenType]

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -35,3 +35,4 @@ export type EffectDef = {
 export type { Result } from './Result'
 export { ok, err } from './Result'
 export { NodeType } from './NodeType'
+export { ScreenType } from './ScreenType'


### PR DESCRIPTION
## 概要

ゲーム全体の状態（現在の画面・プレイヤー・マップ）を管理するZustandストアを実装。
`ScreenType` を `shared/types` に追加（NodeTypeパターンに倣う）。

## 変更内容

- `src/shared/types/ScreenType.ts` 新規作成
- `src/shared/types/index.ts` ScreenType re-export追加
- `src/presentation/viewmodels/useRunViewModel.ts` 新規作成

## 設計判断

- `castDraft` を使用してImmer draft × readonly型の競合を解決
- `Seed.generate()` を使用してistanbul ignoreコメントを削除
- `startRunError: string | null` を追加してサイレント失敗を防止
- `isStarting: boolean` で二重起動を防止

Closes #55