### PR TITLE
feat: T60/T61/T62/T72 エントリーポイント・タイトル/キャラ選択/マップ画面

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { App } from './presentation/react/App'
 
-// TODO: App.tsx に差し替える（T60）
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <div style={{ color: '#fff', padding: '2rem', fontFamily: 'monospace' }}>
-      XxxTheSpire - 開発中
-    </div>
+    <App />
   </React.StrictMode>,
 )

--- a/src/presentation/phaser/scenes/BootScene.ts
+++ b/src/presentation/phaser/scenes/BootScene.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser'
+import { SceneKey } from '../../../shared/constants'
 
 /**
  * BootScene — アセットプリロードシーン
@@ -23,9 +24,8 @@ export class BootScene extends Phaser.Scene {
   private progressBox: Phaser.GameObjects.Graphics | null = null
   private loadingText: Phaser.GameObjects.Text | null = null
 
-  // TODO: SceneKey 定数が定義されたら 'MainMenuScene' をその値に置き換える。
-  constructor(nextScene = 'MainMenuScene') {
-    super({ key: 'BootScene' })
+  constructor(nextScene: string = SceneKey.Map) {
+    super({ key: SceneKey.Boot })
     this.nextScene = nextScene
   }
 

--- a/src/presentation/phaser/scenes/MapScene.ts
+++ b/src/presentation/phaser/scenes/MapScene.ts
@@ -8,6 +8,7 @@ import {
 } from '../EventBus'
 import { NodeType } from '../../../shared/types'
 import type { NodeId } from '../../../shared/types'
+import { SceneKey } from '../../../shared/constants'
 
 /**
  * MapScene — マップ描画シーン
@@ -76,7 +77,7 @@ export class MapScene extends Phaser.Scene {
   private unsubNodeSelected: Unsubscribe | null = null
 
   constructor() {
-    super({ key: 'MapScene' })
+    super({ key: SceneKey.Map })
   }
 
   create(): void {
@@ -87,7 +88,7 @@ export class MapScene extends Phaser.Scene {
 
     this.unsubMapUpdate = EventBus.on('mapUpdate', (payload) => {
       // Guard: discard stale events delivered after the scene was stopped or destroyed.
-      if (!this.scene.isActive('MapScene')) return
+      if (!this.scene.isActive(SceneKey.Map)) return
       this.currentPayload = payload
       // Reset selection when new map data arrives; the previous NodeId may not exist in the
       // new payload (e.g. floor transition) and would cause a stale highlight.
@@ -96,7 +97,7 @@ export class MapScene extends Phaser.Scene {
     })
 
     this.unsubNodeSelected = EventBus.on('nodeSelected', (payload) => {
-      if (!this.scene.isActive('MapScene')) return
+      if (!this.scene.isActive(SceneKey.Map)) return
       this.selectedNodeId = payload.nodeId
       this.renderMap()
     })

--- a/src/presentation/react/App.tsx
+++ b/src/presentation/react/App.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useState } from 'react'
+import { PhaserGame } from '../phaser/PhaserGame'
+import { BootScene } from '../phaser/scenes/BootScene'
+import { MapScene } from '../phaser/scenes/MapScene'
+import { SceneKey, PHASER_BACKGROUND_COLOR } from '../../shared/constants'
+import { ScreenType } from '../../shared/types'
+import { useRunViewModel } from '../viewmodels/useRunViewModel'
+import { TitleScreen } from './screens/TitleScreen'
+import { CharacterSelectScreen } from './screens/CharacterSelectScreen'
+import { MapScreen } from './screens/MapScreen'
+
+// ラン開始前の画面種別（useRunViewModel 管理外の UI フロー）
+type PreRunScreen = 'title' | 'characterSelect'
+
+// シーン配列はマウント時に一度だけ生成される（PhaserGame の仕様に従う）
+const PHASER_SCENES = [new BootScene(SceneKey.Map), new MapScene()]
+
+/**
+ * App — アプリケーションルートコンポーネント
+ *
+ * - ラン開始前: title → characterSelect の UI ナビゲーションを管理する
+ * - ラン開始後: useRunViewModel.currentScreen に応じてゲーム画面をレンダリングする
+ * - Phaser キャンバス（PhaserGame）はマップ画面でのみ表示する
+ *
+ * 参照してよい層: presentation / shared
+ * （DIコンテナは useRunViewModel 経由でのみ使用するため、この層では直接参照しない）
+ */
+export function App(): React.JSX.Element {
+  const [preRunScreen, setPreRunScreen] = useState<PreRunScreen>('title')
+  const { player, currentScreen, startRunError, clearError } = useRunViewModel()
+
+  const isInRun = player !== null
+
+  // 戻るボタン: エラーをクリアしてタイトルに戻る
+  const handleBackToTitle = useCallback(() => {
+    clearError()
+    setPreRunScreen('title')
+  }, [clearError])
+
+  if (!isInRun) {
+    if (preRunScreen === 'title') {
+      return <TitleScreen onNewGame={() => setPreRunScreen('characterSelect')} />
+    }
+    return <CharacterSelectScreen error={startRunError} onBack={handleBackToTitle} />
+  }
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: 1280,
+        height: 720,
+        backgroundColor: PHASER_BACKGROUND_COLOR,
+      }}
+    >
+      {currentScreen === ScreenType.Map && (
+        <>
+          <PhaserGame scenes={PHASER_SCENES} />
+          <MapScreen />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/presentation/react/screens/CharacterSelectScreen.tsx
+++ b/src/presentation/react/screens/CharacterSelectScreen.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { useRunViewModel } from '../../viewmodels/useRunViewModel'
+import { PHASER_BACKGROUND_COLOR } from '../../../shared/constants'
+
+type Props = {
+  onBack: () => void
+  error?: string | null
+}
+
+// 選択可能キャラクター定義（初期はIronclad）
+const CHARACTERS = [
+  {
+    id: 'ironclad',
+    name: 'Ironclad',
+    description: '力強い戦士。攻撃と防御のバランスが取れたデッキを持つ。',
+    startingDeck: 'Strike ×5 / Defend ×4 / Bash ×1',
+  },
+] as const
+
+/**
+ * CharacterSelectScreen — キャラクター選択画面
+ *
+ * プレイするキャラクターを選択し、ランを開始する。
+ * 「選択」ボタン押下 → useRunViewModel.startRun(characterId) → マップ画面へ遷移
+ *
+ * 参照してよい層: presentation/viewmodels のみ
+ */
+export function CharacterSelectScreen({ onBack, error }: Props): React.JSX.Element {
+  const { startRun, isStarting } = useRunViewModel()
+
+  return (
+    <div style={styles.container}>
+      <h2 style={styles.title}>キャラクター選択</h2>
+
+      <div style={styles.characterList}>
+        {CHARACTERS.map((char) => (
+          <div key={char.id} style={styles.characterCard}>
+            <h3 style={styles.characterName}>{char.name}</h3>
+            <p style={styles.description}>{char.description}</p>
+            <p style={styles.deckLabel}>初期デッキ: {char.startingDeck}</p>
+            <button
+              style={isStarting ? styles.buttonDisabled : styles.button}
+              onClick={() => startRun(char.id)}
+              disabled={isStarting}
+            >
+              {isStarting ? '開始中...' : '選択'}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {error !== null && error !== undefined && <p style={styles.error}>エラー: {error}</p>}
+
+      <button
+        style={isStarting ? styles.backButtonDisabled : styles.backButton}
+        onClick={onBack}
+        disabled={isStarting}
+      >
+        ← 戻る
+      </button>
+    </div>
+  )
+}
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    minHeight: '100vh',
+    backgroundColor: PHASER_BACKGROUND_COLOR,
+    color: '#ffffff',
+    fontFamily: 'monospace',
+    padding: '2rem',
+  },
+  title: {
+    fontSize: '2rem',
+    marginBottom: '2rem',
+  },
+  characterList: {
+    display: 'flex',
+    gap: '1.5rem',
+    flexWrap: 'wrap' as const,
+    justifyContent: 'center',
+  },
+  characterCard: {
+    backgroundColor: '#2a2a4e',
+    border: '1px solid #4a4a8e',
+    borderRadius: '8px',
+    padding: '1.5rem',
+    width: '260px',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '0.75rem',
+  },
+  characterName: {
+    fontSize: '1.4rem',
+    margin: 0,
+  },
+  description: {
+    fontSize: '0.9rem',
+    color: '#cccccc',
+    margin: 0,
+    lineHeight: 1.5,
+  },
+  deckLabel: {
+    fontSize: '0.8rem',
+    color: '#aaaaaa',
+    margin: 0,
+  },
+  button: {
+    padding: '0.6rem 1.5rem',
+    fontSize: '1rem',
+    backgroundColor: '#3a3a6e',
+    color: '#ffffff',
+    border: '1px solid #5a5aae',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    marginTop: '0.5rem',
+  },
+  buttonDisabled: {
+    padding: '0.6rem 1.5rem',
+    fontSize: '1rem',
+    backgroundColor: '#333355',
+    color: '#777799',
+    border: '1px solid #333355',
+    borderRadius: '4px',
+    cursor: 'not-allowed',
+    marginTop: '0.5rem',
+  },
+  error: {
+    color: '#ff6666',
+    marginTop: '1rem',
+  },
+  backButton: {
+    marginTop: '2rem',
+    padding: '0.5rem 1.2rem',
+    fontSize: '0.9rem',
+    backgroundColor: 'transparent',
+    color: '#aaaacc',
+    border: '1px solid #4a4a8e',
+    borderRadius: '4px',
+    cursor: 'pointer',
+  },
+  backButtonDisabled: {
+    marginTop: '2rem',
+    padding: '0.5rem 1.2rem',
+    fontSize: '0.9rem',
+    backgroundColor: 'transparent',
+    color: '#555577',
+    border: '1px solid #333355',
+    borderRadius: '4px',
+    cursor: 'not-allowed',
+  },
+} as const

--- a/src/presentation/react/screens/MapScreen.tsx
+++ b/src/presentation/react/screens/MapScreen.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect } from 'react'
+import { useMapViewModel } from '../../viewmodels/useMapViewModel'
+import { EventBus, type MapNodeRenderData } from '../../phaser/EventBus'
+import type { NodeId } from '../../../shared/types'
+import { NodeType } from '../../../shared/types'
+
+// ノード種別の表示ラベル
+const NODE_TYPE_LABEL: Record<NodeType, string> = {
+  [NodeType.Combat]: '戦闘',
+  [NodeType.Elite]: 'エリート',
+  [NodeType.Event]: 'イベント',
+  [NodeType.Shop]: 'ショップ',
+  [NodeType.Rest]: '休憩所',
+  [NodeType.Boss]: 'ボス',
+}
+
+/**
+ * MapScreen — マップ画面
+ *
+ * 現在フロア・選択可能ノードを React UI で表示する。
+ * EventBus 経由で MapScene（Phaser）にマップ状態を送信し、
+ * ノード選択ボタンで useMapViewModel.selectNode() を呼び出す。
+ *
+ * 参照してよい層: presentation（viewmodels, EventBus）のみ
+ */
+export function MapScreen(): React.JSX.Element {
+  const { map, currentNodeId, selectableNodeIds, selectNode, selectNodeError } = useMapViewModel()
+
+  // マップ状態が変化するたびに MapScene（Phaser）へ描画データを送信する
+  useEffect(() => {
+    if (map === null) return
+
+    const nodes: MapNodeRenderData[] = map.flatMap((floor) =>
+      floor.map((node, colIdx) => ({
+        id: node.id,
+        type: node.type,
+        floor: node.floor,
+        column: colIdx,
+        connections: node.connections,
+        visited: node.visited,
+      })),
+    )
+
+    EventBus.emit('mapUpdate', { nodes, currentNodeId, selectableNodeIds })
+  }, [map, currentNodeId, selectableNodeIds])
+
+  const handleSelectNode = (nodeId: NodeId): void => {
+    // nodeSelected は MapScene 側でのノードハイライト即時更新用。
+    // selectNode() が成功すると selectableNodeIds が更新され、
+    // useEffect の依存配列変化により mapUpdate が後続で自動発火する。
+    EventBus.emit('nodeSelected', { nodeId })
+    selectNode(nodeId)
+  }
+
+  if (map === null) {
+    return <div style={styles.loading}>マップを読み込み中...</div>
+  }
+
+  const currentFloor = currentNodeId === null ? 0 : findNodeFloor(map, currentNodeId)
+  const totalFloors = map.length
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <span style={styles.floorInfo}>
+          Act 1 — フロア {currentFloor + 1} / {totalFloors}
+        </span>
+      </div>
+
+      {selectableNodeIds.length > 0 && (
+        <div style={styles.section}>
+          <p style={styles.sectionLabel}>移動先を選択:</p>
+          <div style={styles.nodeList}>
+            {selectableNodeIds.map((nodeId) => {
+              const node = findNode(map, nodeId)
+              if (node === undefined) return null
+              return (
+                <button
+                  key={nodeId}
+                  style={styles.nodeButton}
+                  onClick={() => handleSelectNode(nodeId)}
+                >
+                  {NODE_TYPE_LABEL[node.type]}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {selectableNodeIds.length === 0 && <p style={styles.hint}>進めるノードを選択してください</p>}
+
+      {selectNodeError !== null && <p style={styles.error}>選択エラー: {selectNodeError}</p>}
+    </div>
+  )
+}
+
+/** マップからノードを検索する */
+function findNode(
+  map: ReadonlyArray<ReadonlyArray<{ readonly id: NodeId; readonly type: NodeType }>>,
+  nodeId: NodeId,
+): { readonly id: NodeId; readonly type: NodeType } | undefined {
+  for (const floor of map) {
+    const found = floor.find((n) => n.id === nodeId)
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
+/** ノードが属するフロアインデックスを返す */
+function findNodeFloor(
+  map: ReadonlyArray<ReadonlyArray<{ readonly id: NodeId }>>,
+  nodeId: NodeId,
+): number {
+  for (let i = 0; i < map.length; i++) {
+    if (map[i]!.some((n) => n.id === nodeId)) return i
+  }
+  return 0
+}
+
+const styles = {
+  container: {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    fontFamily: 'monospace',
+    color: '#ffffff',
+    pointerEvents: 'none' as const,
+    zIndex: 10,
+  },
+  header: {
+    padding: '0.75rem 1rem',
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    pointerEvents: 'auto' as const,
+  },
+  floorInfo: {
+    fontSize: '0.95rem',
+    color: '#ccccff',
+  },
+  section: {
+    position: 'absolute' as const,
+    bottom: '2rem',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    pointerEvents: 'auto' as const,
+    textAlign: 'center' as const,
+  },
+  sectionLabel: {
+    fontSize: '0.85rem',
+    color: '#aaaacc',
+    marginBottom: '0.5rem',
+  },
+  nodeList: {
+    display: 'flex',
+    gap: '0.5rem',
+    justifyContent: 'center',
+    flexWrap: 'wrap' as const,
+  },
+  nodeButton: {
+    padding: '0.5rem 1rem',
+    fontSize: '0.9rem',
+    backgroundColor: 'rgba(60,60,140,0.85)',
+    color: '#ffffff',
+    border: '1px solid #6666cc',
+    borderRadius: '4px',
+    cursor: 'pointer',
+  },
+  hint: {
+    position: 'absolute' as const,
+    bottom: '2rem',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    color: '#888888',
+    fontSize: '0.85rem',
+    pointerEvents: 'none' as const,
+  },
+  error: {
+    position: 'absolute' as const,
+    bottom: '5rem',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    color: '#ff6666',
+    fontSize: '0.85rem',
+    pointerEvents: 'none' as const,
+  },
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    backgroundColor: '#1a1a2e',
+    color: '#ffffff',
+    fontFamily: 'monospace',
+  },
+} as const

--- a/src/presentation/react/screens/TitleScreen.tsx
+++ b/src/presentation/react/screens/TitleScreen.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { PHASER_BACKGROUND_COLOR } from '../../../shared/constants'
+
+type Props = {
+  onNewGame: () => void
+  hasSaveData?: boolean
+  onContinue?: () => void
+}
+
+/**
+ * TitleScreen — タイトル画面
+ *
+ * ゲーム起動時に最初に表示される画面。
+ * 「新しいゲーム」でキャラクター選択へ遷移する。
+ * セーブデータが存在する場合のみ「続きから」ボタンを表示する。
+ *
+ * 参照してよい層: presentation/viewmodels のみ
+ */
+export function TitleScreen({
+  onNewGame,
+  hasSaveData = false,
+  onContinue,
+}: Props): React.JSX.Element {
+  return (
+    <div style={styles.container}>
+      <h1 style={styles.title}>XxxTheSpire</h1>
+      <div style={styles.buttonGroup}>
+        <button style={styles.button} onClick={onNewGame}>
+          新しいゲーム
+        </button>
+        {hasSaveData && onContinue !== undefined && (
+          <button style={styles.button} onClick={onContinue}>
+            続きから
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    backgroundColor: PHASER_BACKGROUND_COLOR,
+    color: '#ffffff',
+    fontFamily: 'monospace',
+  },
+  title: {
+    fontSize: '3rem',
+    marginBottom: '2rem',
+    letterSpacing: '0.1em',
+  },
+  buttonGroup: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '1rem',
+    alignItems: 'center',
+  },
+  button: {
+    padding: '0.75rem 2rem',
+    fontSize: '1.1rem',
+    backgroundColor: '#2a2a4e',
+    color: '#ffffff',
+    border: '1px solid #4a4a8e',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    minWidth: '200px',
+  },
+} as const

--- a/src/presentation/viewmodels/useRunViewModel.ts
+++ b/src/presentation/viewmodels/useRunViewModel.ts
@@ -6,6 +6,7 @@ import type { MapNode } from '../../domain/entities/MapNode'
 import { Seed } from '../../domain/value-objects/Seed'
 import { ScreenType } from '../../shared/types/ScreenType'
 import { createContainer } from '../../di/container'
+import { useMapViewModel } from './useMapViewModel'
 
 /**
  * ランViewModel — ゲーム全体の状態を管理するZustandストア
@@ -28,6 +29,7 @@ interface RunState {
   readonly isStarting: boolean
   startRun: (characterId: string) => void
   navigateTo: (screen: ScreenType) => void
+  clearError: () => void
 }
 
 export const useRunViewModel = create<RunState>()(
@@ -50,6 +52,7 @@ export const useRunViewModel = create<RunState>()(
       const result = container.startRunUseCase.execute(characterId, seed)
 
       if (result.ok) {
+        useMapViewModel.getState().initialize(result.value.map)
         set((draft) => {
           draft.player = castDraft(result.value.player)
           draft.map = castDraft(result.value.map)
@@ -67,6 +70,12 @@ export const useRunViewModel = create<RunState>()(
     navigateTo: (screen: ScreenType) => {
       set((draft) => {
         draft.currentScreen = screen
+      })
+    },
+
+    clearError: () => {
+      set((draft) => {
+        draft.startRunError = null
       })
     },
   })),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -56,3 +56,10 @@ export const REST_HEAL_PERCENT = 0.3
 // Phaser
 export const PHASER_BACKGROUND_COLOR = '#1a1a2e'
 export const PHASER_CANVAS_Z_INDEX = 5
+
+// Scene keys — Phaser シーンのキー定数
+export const SceneKey = {
+  Boot: 'BootScene',
+  Map: 'MapScene',
+} as const
+export type SceneKey = (typeof SceneKey)[keyof typeof SceneKey]


### PR DESCRIPTION
## Summary

- `SceneKey` 定数を追加し `BootScene`・`MapScene` のハードコード文字列を排除
- `useRunViewModel` に `useMapViewModel` 初期化処理・`clearError` アクションを追加
- `App.tsx` を新規作成しラン前後の画面ルーティングを実装
- `main.tsx` を `App` コンポーネントに差し替え
- `TitleScreen`・`CharacterSelectScreen`・`MapScreen` を新規作成
- `MapScreen` は `useEffect` 経由で EventBus に `mapUpdate` を送信し `MapScene`（Phaser）と同期

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] `npm run dev` でVite開発サーバーが起動すること
- [ ] タイトル画面が表示されること
- [ ] 「新しいゲーム」→ キャラクター選択画面へ遷移すること
- [ ] 「選択」→ マップ画面へ遷移し Phaser キャンバスにマップが描画されること
- [ ] マップノードのボタンを押すと移動でき、選択可能ノードが更新されること
- [ ] 「戻る」でタイトルに戻り、前回の startRunError が表示されないこと

## 関連 Issue

Closes #60
Closes #61
Closes #62
Closes #72

## スコープ外 Issue（レビューで検出・追跡中）

- #125 useRunViewModel/useMapViewModel クロスストア依存改善
- #126 PhaserGame 常時マウント最適化
- #127 RunState の runData グループ化

🤖 Generated with [Claude Code](https://claude.com/claude-code)