### PR TITLE
feat: T156/T158 RunData discriminated union・subscribeベース同期

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/seedrandom": "^3.0.8",
@@ -335,6 +336,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1617,6 +1628,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2303,6 +2371,17 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2974,6 +3053,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2986,6 +3076,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4866,6 +4964,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5399,6 +5508,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/seedrandom": "^3.0.8",

--- a/src/presentation/hooks/useRunMapSync.ts
+++ b/src/presentation/hooks/useRunMapSync.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+import { useRunViewModel } from '../viewmodels/useRunViewModel'
+import { useMapViewModel } from '../viewmodels/useMapViewModel'
+
+/**
+ * ランVM→マップVM の購読設定（純粋な購読セットアップ）
+ *
+ * useRunViewModel の runData が idle → active に遷移したとき、
+ * useMapViewModel.initialize() を呼び出してマップ状態を初期化する。
+ *
+ * 初期同期（マウント時点ですでに active な場合の処理）は呼び出し側の責務。
+ *
+ * @returns unsubscribe 関数（呼び出し側でクリーンアップする責務を持つ）
+ *
+ * @constraint **必ず useEffect 内でのみ呼び出し、返値の unsubscribe を
+ *   クリーンアップ関数で実行すること。**
+ *   React のライフサイクル外（モジュールトップレベル・イベントハンドラ等）で
+ *   呼び出すと、コンポーネント破棄後も購読が残りメモリリークの原因となる。
+ *   テスト以外のプロダクションコードでは useRunMapSync フックを使用すること。
+ */
+export function createRunMapSubscription(): () => void {
+  return useRunViewModel.subscribe((state, prevState) => {
+    if (state.runData.status === 'active' && prevState.runData.status !== 'active') {
+      useMapViewModel.getState().initialize(state.runData.map)
+    } else if (state.runData.status === 'idle' && prevState.runData.status === 'active') {
+      useMapViewModel.getState().reset()
+    }
+  })
+}
+
+/**
+ * useRunMapSync — ランVM・マップVM間の購読同期フック
+ *
+ * App.tsx のルートで一度だけ呼び出す。
+ * - マウント時点ですでに active な場合は即時初期同期を行う
+ * - コンポーネント破棄時（unmount）に購読を自動解除する
+ *
+ * 依存関係の向き: useRunViewModel → (subscribe) → useMapViewModel
+ * useRunViewModel は useMapViewModel を直接 import しない。
+ */
+export function useRunMapSync(): void {
+  useEffect(() => {
+    // マウント時点ですでに active な場合の初期同期
+    const currentState = useRunViewModel.getState()
+    if (currentState.runData.status === 'active') {
+      useMapViewModel.getState().initialize(currentState.runData.map)
+    }
+
+    const unsubscribe = createRunMapSubscription()
+    return unsubscribe
+  }, [])
+}

--- a/src/presentation/react/App.tsx
+++ b/src/presentation/react/App.tsx
@@ -5,6 +5,7 @@ import { MapScene } from '../phaser/scenes/MapScene'
 import { SceneKey, PHASER_BACKGROUND_COLOR } from '../../shared/constants'
 import { ScreenType } from '../../shared/types'
 import { useRunViewModel } from '../viewmodels/useRunViewModel'
+import { useRunMapSync } from '../hooks/useRunMapSync'
 import { TitleScreen } from './screens/TitleScreen'
 import { CharacterSelectScreen } from './screens/CharacterSelectScreen'
 import { MapScreen } from './screens/MapScreen'
@@ -12,24 +13,25 @@ import { MapScreen } from './screens/MapScreen'
 // ラン開始前の画面種別（useRunViewModel 管理外の UI フロー）
 type PreRunScreen = 'title' | 'characterSelect'
 
-// シーン配列はマウント時に一度だけ生成される（PhaserGame の仕様に従う）
-const PHASER_SCENES = [new BootScene(SceneKey.Map), new MapScene()]
-
 /**
  * App — アプリケーションルートコンポーネント
  *
  * - ラン開始前: title → characterSelect の UI ナビゲーションを管理する
- * - ラン開始後: useRunViewModel.currentScreen に応じてゲーム画面をレンダリングする
+ * - ラン開始後: runData.currentScreen に応じてゲーム画面をレンダリングする
  * - Phaser キャンバス（PhaserGame）はマップ画面でのみ表示する
  *
  * 参照してよい層: presentation / shared
  * （DIコンテナは useRunViewModel 経由でのみ使用するため、この層では直接参照しない）
  */
 export function App(): React.JSX.Element {
-  const [preRunScreen, setPreRunScreen] = useState<PreRunScreen>('title')
-  const { player, currentScreen, startRunError, clearError } = useRunViewModel()
+  useRunMapSync()
 
-  const isInRun = player !== null
+  // シーン配列はマウント時に一度だけ生成される（PhaserGame の仕様に従う）
+  const [phaserScenes] = useState(() => [new BootScene(SceneKey.Map), new MapScene()])
+  const [preRunScreen, setPreRunScreen] = useState<PreRunScreen>('title')
+  const { runData, startRunError, clearError } = useRunViewModel()
+
+  const isInRun = runData.status === 'active'
 
   // 戻るボタン: エラーをクリアしてタイトルに戻る
   const handleBackToTitle = useCallback(() => {
@@ -53,9 +55,9 @@ export function App(): React.JSX.Element {
         backgroundColor: PHASER_BACKGROUND_COLOR,
       }}
     >
-      {currentScreen === ScreenType.Map && (
+      {runData.currentScreen === ScreenType.Map && (
         <>
-          <PhaserGame scenes={PHASER_SCENES} />
+          <PhaserGame scenes={phaserScenes} />
           <MapScreen />
         </>
       )}

--- a/src/presentation/viewmodels/useMapViewModel.ts
+++ b/src/presentation/viewmodels/useMapViewModel.ts
@@ -27,8 +27,12 @@ interface MapState {
   readonly selectableNodeIds: readonly NodeId[]
   /** selectNode失敗時のエラー。成功時・未実行時は null */
   readonly selectNodeError: SelectNodeError | null
-  initialize: (map: ReadonlyArray<ReadonlyArray<MapNode>>, currentNodeId?: NodeId | null) => void
-  selectNode: (targetNodeId: NodeId) => void
+  readonly initialize: (
+    map: ReadonlyArray<ReadonlyArray<MapNode>>,
+    currentNodeId?: NodeId | null,
+  ) => void
+  readonly reset: () => void
+  readonly selectNode: (targetNodeId: NodeId) => void
 }
 
 export const useMapViewModel = create<MapState>()(
@@ -46,6 +50,15 @@ export const useMapViewModel = create<MapState>()(
         draft.map = castDraft(map)
         draft.currentNodeId = currentNodeId
         draft.selectableNodeIds = castDraft(computeSelectableNodeIds(map, currentNodeId))
+        draft.selectNodeError = null
+      })
+    },
+
+    reset: () => {
+      set((draft) => {
+        draft.map = null
+        draft.currentNodeId = null
+        draft.selectableNodeIds = []
         draft.selectNodeError = null
       })
     },

--- a/src/presentation/viewmodels/useRunViewModel.ts
+++ b/src/presentation/viewmodels/useRunViewModel.ts
@@ -6,70 +6,105 @@ import type { MapNode } from '../../domain/entities/MapNode'
 import { Seed } from '../../domain/value-objects/Seed'
 import { ScreenType } from '../../shared/types/ScreenType'
 import { createContainer } from '../../di/container'
-import { useMapViewModel } from './useMapViewModel'
+
+/**
+ * ランデータの discriminated union
+ *
+ * - idle: ラン未開始。player・map・currentScreen にはアクセス不可（型レベルで保証）
+ * - active: ラン進行中。player・map・currentScreen が確定している
+ */
+export type RunData =
+  | { readonly status: 'idle' }
+  | {
+      readonly status: 'active'
+      readonly player: Player
+      readonly map: ReadonlyArray<ReadonlyArray<MapNode>>
+      readonly currentScreen: ScreenType
+    }
 
 /**
  * ランViewModel — ゲーム全体の状態を管理するZustandストア
  *
  * 責務:
- * - 現在表示中の画面（currentScreen）
- * - プレイヤー状態（player）・マップ状態（map）
+ * - ランの開始前後の状態（runData: RunData）
  * - ラン開始（startRun）・画面遷移（navigateTo）アクション
  * - startRun失敗時のエラー状態（startRunError）
  *
  * 参照してはいけない層: infrastructure（DIコンテナ経由でのみアクセス）
+ * クロスストア依存: useMapViewModel を直接 import しない。
+ *   マップ初期化は useRunMapSync フック（App.tsx）が subscribe 経由で行う。
  */
 interface RunState {
-  readonly currentScreen: ScreenType
-  readonly player: Player | null
-  readonly map: MapNode[][] | null
-  /** startRun失敗時のエラーメッセージ。成功時・未実行時は null */
+  readonly runData: RunData
+  /**
+   * startRun失敗時のエラーメッセージ。成功時・未実行時は null。
+   *
+   * 設計意図: runData（RunData discriminated union）はランのライフサイクル状態を表す。
+   * startRunError はランの開始操作の結果を表す UI フィードバック用フィールドであり、
+   * RunData の一部には含めない（ラン状態とエラー表示の関心が異なるため）。
+   */
   readonly startRunError: string | null
   /** startRun実行中フラグ（二重起動防止） */
   readonly isStarting: boolean
-  startRun: (characterId: string) => void
-  navigateTo: (screen: ScreenType) => void
-  clearError: () => void
+  readonly startRun: (characterId: string) => void
+  readonly navigateTo: (screen: ScreenType) => void
+  readonly clearError: () => void
 }
 
 export const useRunViewModel = create<RunState>()(
   immer((set) => ({
-    currentScreen: ScreenType.Map,
-    player: null,
-    map: null,
+    runData: { status: 'idle' },
     startRunError: null,
     isStarting: false,
 
     startRun: (characterId: string) => {
+      if (useRunViewModel.getState().isStarting) return
+
       set((draft) => {
-        if (draft.isStarting) return
         draft.isStarting = true
         draft.startRunError = null
       })
 
       const seed = Seed.generate()
       const container = createContainer(seed)
-      const result = container.startRunUseCase.execute(characterId, seed)
 
-      if (result.ok) {
-        useMapViewModel.getState().initialize(result.value.map)
+      // NOTE: execute は同期処理を前提としている。
+      // 非同期化する場合は isStarting ガードと set() の順序を再設計すること。
+      try {
+        const result = container.startRunUseCase.execute(characterId, seed)
+
+        if (result.ok) {
+          set((draft) => {
+            draft.runData = castDraft({
+              status: 'active' as const,
+              player: result.value.player,
+              map: result.value.map,
+              currentScreen: ScreenType.Map,
+            })
+            draft.isStarting = false
+          })
+        } else {
+          set((draft) => {
+            draft.startRunError = result.error
+            draft.isStarting = false
+          })
+        }
+      } catch (e) {
         set((draft) => {
-          draft.player = castDraft(result.value.player)
-          draft.map = castDraft(result.value.map)
-          draft.currentScreen = ScreenType.Map
           draft.isStarting = false
         })
-      } else {
-        set((draft) => {
-          draft.startRunError = result.error
-          draft.isStarting = false
-        })
+        throw e
       }
     },
 
     navigateTo: (screen: ScreenType) => {
       set((draft) => {
-        draft.currentScreen = screen
+        if (draft.runData.status === 'active') {
+          draft.runData = castDraft({
+            ...draft.runData,
+            currentScreen: screen,
+          })
+        }
       })
     },
 

--- a/tests/presentation/__helpers__/index.ts
+++ b/tests/presentation/__helpers__/index.ts
@@ -1,0 +1,64 @@
+import type { MapNode } from '../../../src/domain/entities/MapNode'
+import type { Player } from '../../../src/domain/entities/Player'
+import type { NodeId } from '../../../src/shared/types'
+import { NodeType } from '../../../src/shared/types'
+import { ScreenType } from '../../../src/shared/types/ScreenType'
+import { useRunViewModel } from '../../../src/presentation/viewmodels/useRunViewModel'
+import { useMapViewModel } from '../../../src/presentation/viewmodels/useMapViewModel'
+
+export function makeMapNode(id: string, floor: number): MapNode {
+  return { id: id as NodeId, type: NodeType.Combat, floor, connections: [], visited: false }
+}
+
+export const MOCK_MAP: ReadonlyArray<ReadonlyArray<MapNode>> = [
+  [makeMapNode('node-0', 0)],
+  [makeMapNode('node-1', 1)],
+]
+
+export const MOCK_PLAYER = {
+  id: 'ironclad',
+  name: 'Ironclad',
+  health: { current: 80, max: 80 },
+  energy: { current: 3, max: 3 },
+  gold: { amount: 99 },
+  block: { value: 0 },
+  deck: [],
+  hand: [],
+  discardPile: [],
+  exhaustPile: [],
+  relics: [],
+  powers: [],
+  statusEffects: [],
+  potions: [null, null, null],
+  maxPotionSlots: 3,
+} as unknown as Player
+
+export function setActiveRunState(): void {
+  useRunViewModel.setState({
+    runData: {
+      status: 'active',
+      player: MOCK_PLAYER,
+      map: MOCK_MAP,
+      currentScreen: ScreenType.Map,
+    },
+    isStarting: false,
+    startRunError: null,
+  })
+}
+
+export function setIdleRunState(): void {
+  useRunViewModel.setState({
+    runData: { status: 'idle' },
+    isStarting: false,
+    startRunError: null,
+  })
+}
+
+export function resetMapViewModel(): void {
+  useMapViewModel.setState({
+    map: null,
+    currentNodeId: null,
+    selectableNodeIds: [],
+    selectNodeError: null,
+  })
+}

--- a/tests/presentation/hooks/useRunMapSync.test.ts
+++ b/tests/presentation/hooks/useRunMapSync.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  createRunMapSubscription,
+  useRunMapSync,
+} from '../../../src/presentation/hooks/useRunMapSync'
+import { useRunViewModel } from '../../../src/presentation/viewmodels/useRunViewModel'
+import { useMapViewModel } from '../../../src/presentation/viewmodels/useMapViewModel'
+import type { MapNode } from '../../../src/domain/entities/MapNode'
+import { ScreenType } from '../../../src/shared/types/ScreenType'
+import {
+  makeMapNode,
+  MOCK_MAP,
+  MOCK_PLAYER,
+  setActiveRunState,
+  setIdleRunState,
+  resetMapViewModel,
+} from '../__helpers__'
+
+// --- Mocks ---
+
+vi.mock('../../../src/di/container', () => ({
+  createContainer: vi.fn(),
+}))
+
+// --- Setup ---
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setIdleRunState()
+  resetMapViewModel()
+})
+
+// ============================================================
+// createRunMapSubscription — 購読設定のみ（初期同期なし）
+// ============================================================
+
+describe('createRunMapSubscription', () => {
+  describe('購読設定（初期同期は行わない）', () => {
+    it('1. マウント時に active でも useMapViewModel は初期化しない（初期同期は呼び出し側の責務）', () => {
+      setActiveRunState()
+      const unsubscribe = createRunMapSubscription()
+
+      // createRunMapSubscription 自体は初期同期をしない
+      expect(useMapViewModel.getState().map).toBeNull()
+
+      unsubscribe()
+    })
+
+    it('2. マウント時に idle でも useMapViewModel は変化しない', () => {
+      const unsubscribe = createRunMapSubscription()
+      expect(useMapViewModel.getState().map).toBeNull()
+      unsubscribe()
+    })
+  })
+
+  describe('idle → active 遷移の通知', () => {
+    it('3. idle → active 遷移時に useMapViewModel が初期化されること', () => {
+      const unsubscribe = createRunMapSubscription()
+      expect(useMapViewModel.getState().map).toBeNull()
+
+      setActiveRunState()
+
+      expect(useMapViewModel.getState().map).not.toBeNull()
+      expect(useMapViewModel.getState().map).toHaveLength(MOCK_MAP.length)
+
+      unsubscribe()
+    })
+
+    it('4. active → active 遷移では useMapViewModel は再初期化されないこと', () => {
+      setActiveRunState()
+      const unsubscribe = createRunMapSubscription()
+      const mapBefore = useMapViewModel.getState().map
+
+      // active → active（status は変わらない）
+      const newMap: ReadonlyArray<ReadonlyArray<MapNode>> = [[makeMapNode('new-node-0', 0)]]
+      useRunViewModel.setState({
+        runData: {
+          status: 'active',
+          player: MOCK_PLAYER,
+          map: newMap,
+          currentScreen: ScreenType.Map,
+        },
+      })
+
+      expect(useMapViewModel.getState().map).toBe(mapBefore)
+      unsubscribe()
+    })
+
+    it('5. active → idle 遷移時に useMapViewModel がリセットされること', () => {
+      setActiveRunState()
+      const unsubscribe = createRunMapSubscription()
+      useMapViewModel.getState().initialize(MOCK_MAP) // 事前に初期化しておく
+
+      setIdleRunState()
+      unsubscribe() // assertion 前にクリーンアップ（失敗時のリーク防止）
+
+      expect(useMapViewModel.getState().map).toBeNull()
+      expect(useMapViewModel.getState().currentNodeId).toBeNull()
+      expect(useMapViewModel.getState().selectableNodeIds).toHaveLength(0)
+    })
+  })
+
+  describe('クリーンアップ', () => {
+    it('6. unsubscribe 後は idle → active 遷移しても useMapViewModel が更新されないこと', () => {
+      const unsubscribe = createRunMapSubscription()
+      unsubscribe()
+
+      setActiveRunState()
+
+      expect(useMapViewModel.getState().map).toBeNull()
+    })
+
+    it('7. createRunMapSubscription が unsubscribe 関数を返すこと', () => {
+      const unsubscribe = createRunMapSubscription()
+      expect(typeof unsubscribe).toBe('function')
+      unsubscribe()
+    })
+  })
+
+  describe('複数購読の独立性', () => {
+    it('S-2. 複数の createRunMapSubscription を同時に設定したとき、それぞれの unsubscribe が独立して動作すること', () => {
+      const unsubscribe1 = createRunMapSubscription()
+      const unsubscribe2 = createRunMapSubscription()
+
+      // unsubscribe1 のみ解除
+      unsubscribe1()
+
+      // idle → active 遷移: unsubscribe2 はまだ有効なので初期化される
+      setActiveRunState()
+      expect(useMapViewModel.getState().map).not.toBeNull()
+
+      // map をリセットして unsubscribe2 も解除
+      useMapViewModel.setState({
+        map: null,
+        currentNodeId: null,
+        selectableNodeIds: [],
+        selectNodeError: null,
+      })
+      unsubscribe2()
+
+      setIdleRunState()
+      setActiveRunState()
+
+      // 両方解除済みなので map は null のまま
+      expect(useMapViewModel.getState().map).toBeNull()
+    })
+  })
+})
+
+// ============================================================
+// useRunMapSync — React フックのライフサイクル（#9）
+// ============================================================
+
+describe('useRunMapSync', () => {
+  describe('マウント時の初期同期', () => {
+    it('H-1. マウント時に runData が active なら useMapViewModel が即座に初期化されること', () => {
+      setActiveRunState()
+
+      renderHook(() => useRunMapSync())
+
+      expect(useMapViewModel.getState().map).not.toBeNull()
+      expect(useMapViewModel.getState().map).toHaveLength(MOCK_MAP.length)
+    })
+
+    it('H-2. マウント時に runData が idle なら useMapViewModel は初期化されないこと', () => {
+      // runData は idle（beforeEach でリセット済み）
+      renderHook(() => useRunMapSync())
+
+      expect(useMapViewModel.getState().map).toBeNull()
+    })
+  })
+
+  describe('マウント後の動的遷移', () => {
+    it('H-5. マウント後に idle → active 遷移したとき useMapViewModel が更新されること', () => {
+      renderHook(() => useRunMapSync())
+      expect(useMapViewModel.getState().map).toBeNull()
+
+      act(() => {
+        setActiveRunState()
+      })
+
+      expect(useMapViewModel.getState().map).not.toBeNull()
+    })
+
+    it('H-6. マウント後に active → idle 遷移したとき useMapViewModel がリセットされること', () => {
+      setActiveRunState()
+      const { unmount } = renderHook(() => useRunMapSync())
+      expect(useMapViewModel.getState().map).not.toBeNull()
+
+      act(() => {
+        setIdleRunState()
+      })
+      unmount() // assertion 前にクリーンアップ（失敗時のリーク防止）
+
+      expect(useMapViewModel.getState().map).toBeNull()
+      expect(useMapViewModel.getState().currentNodeId).toBeNull()
+      expect(useMapViewModel.getState().selectableNodeIds).toHaveLength(0)
+    })
+  })
+
+  describe('unmount 時のクリーンアップ（AC2: メモリリーク防止）', () => {
+    it('H-3. unmount 後は idle → active 遷移しても useMapViewModel が更新されないこと', () => {
+      const { unmount } = renderHook(() => useRunMapSync())
+
+      unmount()
+
+      act(() => {
+        setActiveRunState()
+      })
+
+      // 購読が解除されているため map は null のまま
+      expect(useMapViewModel.getState().map).toBeNull()
+    })
+
+    it('H-4. unmount 後に再マウントしたとき購読が正常に再設定されること', () => {
+      const { unmount } = renderHook(() => useRunMapSync())
+      unmount()
+
+      // 再マウント
+      renderHook(() => useRunMapSync())
+
+      act(() => {
+        setActiveRunState()
+      })
+
+      expect(useMapViewModel.getState().map).not.toBeNull()
+    })
+  })
+})

--- a/tests/presentation/viewmodels/useRunViewModel.test.ts
+++ b/tests/presentation/viewmodels/useRunViewModel.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useRunViewModel } from '../../../src/presentation/viewmodels/useRunViewModel'
+import type { RunData } from '../../../src/presentation/viewmodels/useRunViewModel'
+import { ScreenType } from '../../../src/shared/types/ScreenType'
+
+// --- Mocks ---
+
+vi.mock('../../../src/di/container', () => ({
+  createContainer: vi.fn(),
+}))
+
+import { createContainer } from '../../../src/di/container'
+import { MOCK_MAP, MOCK_PLAYER } from '../__helpers__'
+
+function makeSuccessContainer() {
+  return {
+    startRunUseCase: {
+      execute: vi.fn().mockReturnValue({
+        ok: true,
+        value: { player: MOCK_PLAYER, map: MOCK_MAP },
+      }),
+    },
+  }
+}
+
+function makeFailureContainer(error: string) {
+  return {
+    startRunUseCase: {
+      execute: vi.fn().mockReturnValue({ ok: false, error }),
+    },
+  }
+}
+
+// --- Setup ---
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Zustand ストアを初期状態にリセット（アクション関数は保持されるため merge で OK）
+  useRunViewModel.setState({
+    runData: { status: 'idle' },
+    startRunError: null,
+    isStarting: false,
+  })
+})
+
+// --- Tests ---
+
+describe('useRunViewModel', () => {
+  describe('初期状態', () => {
+    it('1. runData.status が "idle" であること', () => {
+      const { runData } = useRunViewModel.getState()
+      expect(runData.status).toBe('idle')
+    })
+
+    it('2. startRunError が null であること', () => {
+      const { startRunError } = useRunViewModel.getState()
+      expect(startRunError).toBeNull()
+    })
+
+    it('3. isStarting が false であること', () => {
+      const { isStarting } = useRunViewModel.getState()
+      expect(isStarting).toBe(false)
+    })
+
+    it('4. idle 状態では player・map・currentScreen にアクセス不可（TypeScript 型で保証）', () => {
+      const { runData } = useRunViewModel.getState()
+      // idle 状態では status === 'idle' の narrowing が必要。
+      // アクセスしようとすると TypeScript コンパイルエラーになる（実行時は型チェックで防ぐ）。
+      expect(runData.status).toBe('idle')
+      if (runData.status === 'active') {
+        // このブロックは実行されない（idle 状態のため）
+        expect(runData.player).toBeDefined()
+      }
+    })
+  })
+
+  describe('startRun — 正常系', () => {
+    beforeEach(() => {
+      vi.mocked(createContainer).mockReturnValue(
+        makeSuccessContainer() as unknown as ReturnType<typeof createContainer>,
+      )
+    })
+
+    it('5. startRun 後に runData.status が "active" になること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      const { runData } = useRunViewModel.getState()
+      expect(runData.status).toBe('active')
+    })
+
+    it('6. active 状態では runData.player が存在すること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      const { runData } = useRunViewModel.getState()
+      if (runData.status !== 'active') throw new Error('Expected active')
+      expect(runData.player.id).toBe('ironclad')
+    })
+
+    it('7. active 状態では runData.map が存在すること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      const { runData } = useRunViewModel.getState()
+      if (runData.status !== 'active') throw new Error('Expected active')
+      expect(Array.isArray(runData.map)).toBe(true)
+      expect(runData.map.length).toBeGreaterThan(0)
+    })
+
+    it('8. active 状態では runData.currentScreen が ScreenType.Map であること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      const { runData } = useRunViewModel.getState()
+      if (runData.status !== 'active') throw new Error('Expected active')
+      expect(runData.currentScreen).toBe(ScreenType.Map)
+    })
+
+    it('9. startRun 成功後に startRunError が null であること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      expect(useRunViewModel.getState().startRunError).toBeNull()
+    })
+
+    it('10. startRun 成功後に isStarting が false であること', () => {
+      useRunViewModel.getState().startRun('ironclad')
+      expect(useRunViewModel.getState().isStarting).toBe(false)
+    })
+  })
+
+  describe('startRun — 異常系', () => {
+    beforeEach(() => {
+      vi.mocked(createContainer).mockReturnValue(
+        makeFailureContainer('unknown character') as unknown as ReturnType<typeof createContainer>,
+      )
+    })
+
+    it('11. 失敗時に runData.status が "idle" のまま変わらないこと', () => {
+      useRunViewModel.getState().startRun('silent')
+      const { runData } = useRunViewModel.getState()
+      expect(runData.status).toBe('idle')
+    })
+
+    it('12. 失敗時に startRunError がセットされること', () => {
+      useRunViewModel.getState().startRun('silent')
+      expect(useRunViewModel.getState().startRunError).toBe('unknown character')
+    })
+
+    it('13. 失敗時に isStarting が false に戻ること', () => {
+      useRunViewModel.getState().startRun('silent')
+      expect(useRunViewModel.getState().isStarting).toBe(false)
+    })
+  })
+
+  describe('navigateTo', () => {
+    it('14. idle 状態で navigateTo を呼んでも runData が変わらないこと', () => {
+      useRunViewModel.getState().navigateTo(ScreenType.Map)
+      const { runData } = useRunViewModel.getState()
+      expect(runData.status).toBe('idle')
+    })
+
+    it('15. active 状態で navigateTo すると runData.currentScreen が変更されること', () => {
+      vi.mocked(createContainer).mockReturnValue(
+        makeSuccessContainer() as unknown as ReturnType<typeof createContainer>,
+      )
+      useRunViewModel.getState().startRun('ironclad')
+      // 初期値は Map なので別の画面（Combat）に遷移して変化を確認する
+      useRunViewModel.getState().navigateTo(ScreenType.Combat)
+      const { runData } = useRunViewModel.getState()
+      if (runData.status !== 'active') throw new Error('Expected active')
+      expect(runData.currentScreen).toBe(ScreenType.Combat)
+    })
+  })
+
+  describe('clearError', () => {
+    it('16. clearError で startRunError が null になること', () => {
+      vi.mocked(createContainer).mockReturnValue(
+        makeFailureContainer('unknown character') as unknown as ReturnType<typeof createContainer>,
+      )
+      useRunViewModel.getState().startRun('silent')
+      expect(useRunViewModel.getState().startRunError).not.toBeNull()
+
+      useRunViewModel.getState().clearError()
+      expect(useRunViewModel.getState().startRunError).toBeNull()
+    })
+  })
+
+  describe('二重起動防止', () => {
+    it('17. isStarting 中に startRun を呼んでも createContainer が1回しか呼ばれないこと', () => {
+      // isStarting を手動で true にした状態でテスト
+      useRunViewModel.setState({ isStarting: true })
+      vi.mocked(createContainer).mockReturnValue(
+        makeSuccessContainer() as unknown as ReturnType<typeof createContainer>,
+      )
+      useRunViewModel.getState().startRun('ironclad')
+      expect(createContainer).not.toHaveBeenCalled()
+    })
+
+    it('R-3. active 状態から startRun を再度呼んだとき isStarting ガードが機能すること', () => {
+      vi.mocked(createContainer).mockReturnValue(
+        makeSuccessContainer() as unknown as ReturnType<typeof createContainer>,
+      )
+      // 先に active にしてから isStarting を true にセット
+      useRunViewModel.getState().startRun('ironclad')
+      expect(useRunViewModel.getState().runData.status).toBe('active')
+
+      useRunViewModel.setState({ isStarting: true })
+      vi.clearAllMocks()
+
+      useRunViewModel.getState().startRun('ironclad')
+      expect(createContainer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearError — エッジケース', () => {
+    it('R-1. idle + startRunError=null の状態で clearError を呼んでも副作用が発生しないこと', () => {
+      const stateBefore = useRunViewModel.getState()
+      expect(stateBefore.startRunError).toBeNull()
+      expect(stateBefore.runData.status).toBe('idle')
+
+      useRunViewModel.getState().clearError()
+
+      const stateAfter = useRunViewModel.getState()
+      expect(stateAfter.startRunError).toBeNull()
+      expect(stateAfter.runData.status).toBe('idle')
+      expect(stateAfter.isStarting).toBe(false)
+    })
+  })
+
+  describe('navigateTo — エッジケース', () => {
+    it('R-2. idle で navigateTo を呼んでも startRunError・isStarting が変化しないこと', () => {
+      // startRunError をセットしておく
+      vi.mocked(createContainer).mockReturnValue(
+        makeFailureContainer('error') as unknown as ReturnType<typeof createContainer>,
+      )
+      useRunViewModel.getState().startRun('silent')
+      expect(useRunViewModel.getState().startRunError).toBe('error')
+
+      useRunViewModel.getState().navigateTo(ScreenType.Map)
+
+      expect(useRunViewModel.getState().startRunError).toBe('error')
+      expect(useRunViewModel.getState().isStarting).toBe(false)
+      expect(useRunViewModel.getState().runData.status).toBe('idle')
+    })
+  })
+})
+
+// TypeScript 型レベル検証（コンパイル時チェック）
+// RunData が discriminated union として正しく機能していることを型レベルで検証する。
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _typeCheck(runData: RunData) {
+  if (runData.status === 'active') {
+    // active 状態では narrowing により player・map・currentScreen にアクセス可能
+    const _player = runData.player
+    const _map = runData.map
+    const _screen = runData.currentScreen
+    void _player
+    void _map
+    void _screen
+  }
+  // narrowing なしで player に直接アクセスしようとすると TypeScript コンパイルエラーになる:
+  // @ts-expect-error RunData には player プロパティが直接存在しない（status 絞り込みが必要）
+  const _illegalAccess = runData.player
+  void _illegalAccess
+}


### PR DESCRIPTION
## Summary

- **#158** `RunData` discriminated union（`idle`/`active`）を導入。ラン未開始時に `player`・`map`・`currentScreen` へのアクセスを型レベルで禁止し、実行時エラーを排除
- **#156** `useRunViewModel` から `useMapViewModel` の direct import を削除。`useRunMapSync` フックで Zustand `subscribe` ベースの一方向同期に切り替え、メモリリークを解消
- コードレビュー（typescript-reviewer・architect）指摘への対応: `isStarting` 固着防止・`readonly` 統一・`PHASER_SCENES` lazy初期化・テストヘルパー共通化・active→idle 時のマップリセット

## Test plan

- [ ] `npm run test` — 308テスト通過（`useRunViewModel.test.ts` 20件・`useRunMapSync.test.ts` 14件含む）
- [ ] `npm run typecheck` — 型エラーなし（`_typeCheck` 関数で discriminated union の型ナロウイングも確認）
- [ ] `npm run lint` — lint エラーなし
- [ ] idle 状態で `navigateTo` を呼んでも状態が変化しないこと
- [ ] `startRun` 成功後に `runData.status === 'active'` になること
- [ ] コンポーネント unmount 後に購読が解除されること（H-3テスト）
- [ ] active→idle 遷移時に `useMapViewModel` がリセットされること（test 5・H-6テスト）

Closes #156
Closes #158