### PR TITLE
feat: T134 キャラクター定義をリポジトリから取得できる

### DIFF
--- a/src/application/usecases/StartRunUseCase.ts
+++ b/src/application/usecases/StartRunUseCase.ts
@@ -1,4 +1,4 @@
-import { type Result, ok, err } from '../../shared/types'
+import { type Result, type CharacterId, ok, err } from '../../shared/types'
 import { Health } from '../../domain/value-objects/Health'
 import { Energy } from '../../domain/value-objects/Energy'
 import { Gold } from '../../domain/value-objects/Gold'
@@ -8,31 +8,28 @@ import { type Player } from '../../domain/entities/Player'
 import { type MapNode } from '../../domain/entities/MapNode'
 import { type Card } from '../../domain/entities/Card'
 import { type ICardRepository } from '../../domain/interfaces/ICardRepository'
+import { type ICharacterRepository } from '../../domain/interfaces/ICharacterRepository'
 import { generateMap } from '../../domain/rules/MapGenerator'
-import {
-  STARTING_ENERGY,
-  MAX_ENERGY,
-  STARTING_GOLD,
-  MAX_POTIONS,
-  MAP_FLOORS_PER_ACT,
-  MAP_WIDTH,
-  IRONCLAD_STARTING_HP,
-  IRONCLAD_STARTING_DECK,
-} from '../../shared/constants'
+import { STARTING_GOLD, MAX_POTIONS, MAP_FLOORS_PER_ACT, MAP_WIDTH } from '../../shared/constants'
 
 export class StartRunUseCase {
-  constructor(private readonly cardRepo: ICardRepository) {}
+  constructor(
+    private readonly cardRepo: ICardRepository,
+    private readonly characterRepo: ICharacterRepository,
+  ) {}
 
-  execute(characterId: string, seed: Seed): Result<{ player: Player; map: MapNode[][] }, string> {
-    // TODO: T111 CharacterRepository 実装後、ICharacterRepository.findById(characterId) に置き換える。
-    // 現在は Ironclad のみ対応（暫定実装）。
-    if (characterId !== 'ironclad') {
+  execute(
+    characterId: CharacterId,
+    seed: Seed,
+  ): Result<{ player: Player; map: MapNode[][] }, string> {
+    const character = this.characterRepo.findById(characterId)
+    if (character === undefined) {
       return err('unknown character')
     }
 
     // Build initial deck
     const deck: Card[] = []
-    for (const { id, count } of IRONCLAD_STARTING_DECK) {
+    for (const { id, count } of character.startingDeck) {
       const card = this.cardRepo.findById(id)
       if (card === undefined) {
         return err(`Card not found: ${id}`)
@@ -43,10 +40,10 @@ export class StartRunUseCase {
     }
 
     // Create value objects
-    const healthResult = Health.create(IRONCLAD_STARTING_HP, IRONCLAD_STARTING_HP)
+    const healthResult = Health.create(character.startingHp, character.startingHp)
     if (!healthResult.ok) return err(healthResult.error)
 
-    const energyResult = Energy.create(STARTING_ENERGY, MAX_ENERGY)
+    const energyResult = Energy.create(character.maxEnergy, character.maxEnergy)
     if (!energyResult.ok) return err(energyResult.error)
 
     const goldResult = Gold.create(STARTING_GOLD)
@@ -57,8 +54,8 @@ export class StartRunUseCase {
 
     // Build player
     const player: Player = {
-      id: 'ironclad',
-      name: 'Ironclad',
+      id: character.id,
+      name: character.name,
       health: healthResult.value,
       energy: energyResult.value,
       gold: goldResult.value,

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -1,9 +1,11 @@
 import { type ICardRepository } from '../domain/interfaces/ICardRepository'
+import { type ICharacterRepository } from '../domain/interfaces/ICharacterRepository'
 import { type IRandomService } from '../domain/interfaces/IRandomService'
 import { type IRelicRepository } from '../domain/interfaces/IRelicRepository'
 import { type ISaveRepository } from '../domain/interfaces/ISaveRepository'
 import type { Seed } from '../domain/value-objects/Seed'
 import { JsonCardRepository } from '../infrastructure/repositories/JsonCardRepository'
+import { JsonCharacterRepository } from '../infrastructure/repositories/JsonCharacterRepository'
 import { JsonRelicRepository } from '../infrastructure/repositories/JsonRelicRepository'
 import { LocalStorageSaveRepository } from '../infrastructure/repositories/LocalStorageSaveRepository'
 import { SeededRandomService } from '../infrastructure/services/SeededRandomService'
@@ -22,6 +24,7 @@ import { StartRunUseCase } from '../application/usecases/StartRunUseCase'
 export type Container = {
   readonly randomService: IRandomService
   readonly cardRepository: ICardRepository
+  readonly characterRepository: ICharacterRepository
   readonly relicRepository: IRelicRepository
   readonly saveRepository: ISaveRepository
   readonly startRunUseCase: StartRunUseCase // 具象クラス型（意識的設計。上記 NOTE 参照）。
@@ -42,14 +45,16 @@ export type Container = {
 export function createContainer(seed: Seed): Container {
   const randomService = new SeededRandomService(seed)
   const cardRepository = new JsonCardRepository()
+  const characterRepository = new JsonCharacterRepository()
   const relicRepository = new JsonRelicRepository()
   const saveRepository = new LocalStorageSaveRepository()
 
-  const startRunUseCase = new StartRunUseCase(cardRepository)
+  const startRunUseCase = new StartRunUseCase(cardRepository, characterRepository)
 
   return {
     randomService,
     cardRepository,
+    characterRepository,
     relicRepository,
     saveRepository,
     startRunUseCase,

--- a/src/domain/entities/CharacterDefinition.ts
+++ b/src/domain/entities/CharacterDefinition.ts
@@ -1,0 +1,28 @@
+import { type CardId, type CharacterId, type RelicId } from '../../shared/types'
+
+/**
+ * スターターデッキエントリ
+ *
+ * キャラクターの初期デッキにおけるカードIDと枚数のペア。
+ */
+export type StarterDeckEntry = {
+  readonly id: CardId
+  readonly count: number
+}
+
+/**
+ * キャラクター定義
+ *
+ * キャラクタークラス（Ironclad・Silent等）の静的マスターデータ。
+ * ラン開始時のプレイヤー初期状態を構築するために使用する。
+ *
+ * 参照可能な層: shared/types のみ（domain ロジック依存ゼロ）
+ */
+export type CharacterDefinition = {
+  readonly id: CharacterId
+  readonly name: string
+  readonly startingHp: number
+  readonly maxEnergy: number
+  readonly startingDeck: ReadonlyArray<StarterDeckEntry>
+  readonly startingRelicId: RelicId
+}

--- a/src/domain/interfaces/ICardRepository.ts
+++ b/src/domain/interfaces/ICardRepository.ts
@@ -1,3 +1,4 @@
+import { type CardId } from '../../shared/types'
 import { type Card } from '../entities/Card'
 import { type Rarity } from '../enums/Rarity'
 
@@ -5,10 +6,10 @@ import { type Rarity } from '../enums/Rarity'
  * カードリポジトリインターフェース
  *
  * カードマスターデータ取得の契約。
- * 参照可能な層: domain/entities, domain/enums のみ
+ * 参照可能な層: domain/entities, domain/enums, shared/types のみ
  */
 export interface ICardRepository {
-  findById(id: string): Card | undefined
+  findById(id: CardId): Card | undefined
   findAll(): readonly Card[]
   findByRarity(rarity: Rarity): readonly Card[]
 }

--- a/src/domain/interfaces/ICharacterRepository.ts
+++ b/src/domain/interfaces/ICharacterRepository.ts
@@ -1,0 +1,13 @@
+import { type CharacterId } from '../../shared/types'
+import { type CharacterDefinition } from '../entities/CharacterDefinition'
+
+/**
+ * キャラクターリポジトリインターフェース
+ *
+ * キャラクターマスターデータ取得の契約。
+ * 参照可能な層: domain/entities のみ
+ */
+export interface ICharacterRepository {
+  findById(characterId: CharacterId): CharacterDefinition | undefined
+  findAll(): readonly CharacterDefinition[]
+}

--- a/src/infrastructure/data/characters/ironclad.json
+++ b/src/infrastructure/data/characters/ironclad.json
@@ -1,0 +1,12 @@
+{
+  "id": "ironclad",
+  "name": "Ironclad",
+  "starting_hp": 80,
+  "max_energy": 3,
+  "starting_deck": [
+    { "id": "strike_r", "count": 5 },
+    { "id": "defend_r", "count": 4 },
+    { "id": "bash", "count": 1 }
+  ],
+  "starting_relic_id": "burning_blood"
+}

--- a/src/infrastructure/data/characters/silent.json
+++ b/src/infrastructure/data/characters/silent.json
@@ -1,0 +1,11 @@
+{
+  "id": "silent",
+  "name": "Silent",
+  "starting_hp": 70,
+  "max_energy": 3,
+  "starting_deck": [
+    { "id": "strike_g", "count": 6 },
+    { "id": "defend_g", "count": 6 }
+  ],
+  "starting_relic_id": "ring_of_the_snake"
+}

--- a/src/infrastructure/data/schemas.ts
+++ b/src/infrastructure/data/schemas.ts
@@ -88,3 +88,30 @@ export const PotionSchema = z.object({
 })
 
 export type PotionRaw = z.infer<typeof PotionSchema>
+
+/**
+ * スターターデッキエントリのraw形状スキーマ
+ */
+export const StarterDeckEntrySchema = z.object({
+  id: z.string().min(1),
+  count: z.number().int().positive(),
+})
+
+export type StarterDeckEntryRaw = z.infer<typeof StarterDeckEntrySchema>
+
+/**
+ * キャラクターJSONのraw形状スキーマ
+ *
+ * フィールド名はsnake_case（JSONのraw形状）。
+ * ドメイン型のcamelCaseへの変換はリポジトリのマッパー関数で行う。
+ */
+export const CharacterSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  starting_hp: z.number().int().positive(),
+  max_energy: z.number().int().positive(),
+  starting_deck: z.array(StarterDeckEntrySchema).min(1),
+  starting_relic_id: z.string().min(1),
+})
+
+export type CharacterRaw = z.infer<typeof CharacterSchema>

--- a/src/infrastructure/repositories/JsonCardRepository.ts
+++ b/src/infrastructure/repositories/JsonCardRepository.ts
@@ -61,7 +61,7 @@ export class JsonCardRepository implements ICardRepository {
     })
   }
 
-  findById(id: string): Card | undefined {
+  findById(id: CardId): Card | undefined {
     return this.cards.find((card) => card.id === id)
   }
 

--- a/src/infrastructure/repositories/JsonCharacterRepository.ts
+++ b/src/infrastructure/repositories/JsonCharacterRepository.ts
@@ -1,0 +1,62 @@
+import {
+  type CharacterDefinition,
+  type StarterDeckEntry,
+} from '../../domain/entities/CharacterDefinition'
+import { type ICharacterRepository } from '../../domain/interfaces/ICharacterRepository'
+import { type CardId, type CharacterId, type RelicId } from '../../shared/types'
+import { CharacterSchema, type CharacterRaw, type StarterDeckEntryRaw } from '../data/schemas'
+import ironcladData from '../data/characters/ironclad.json'
+import silentData from '../data/characters/silent.json'
+
+/**
+ * スターターデッキエントリの変換
+ *
+ * StarterDeckEntryRaw（snake_case）→ StarterDeckEntry（camelCase）へのマッピング。
+ */
+function toStarterDeckEntry(raw: StarterDeckEntryRaw): StarterDeckEntry {
+  return {
+    id: raw.id as CardId,
+    count: raw.count,
+  }
+}
+
+/**
+ * CharacterRaw（snake_case）→ CharacterDefinition（camelCase）へのマッパー
+ */
+function toCharacterDefinition(raw: CharacterRaw): CharacterDefinition {
+  return {
+    id: raw.id as CharacterId,
+    name: raw.name,
+    startingHp: raw.starting_hp,
+    maxEnergy: raw.max_energy,
+    startingDeck: raw.starting_deck.map(toStarterDeckEntry),
+    startingRelicId: raw.starting_relic_id as RelicId,
+  }
+}
+
+/**
+ * JSONファイルベースのキャラクターリポジトリ
+ *
+ * JSONファイルをZodスキーマで検証し、CharacterDefinitionとして返す。
+ * 参照可能な層: domain/interfaces, domain/entities, shared/types,
+ *               infrastructure/data
+ */
+export class JsonCharacterRepository implements ICharacterRepository {
+  private readonly characters: readonly CharacterDefinition[]
+
+  constructor() {
+    const rawData: unknown[] = [ironcladData, silentData]
+    this.characters = rawData.map((raw) => {
+      const parsed = CharacterSchema.parse(raw)
+      return toCharacterDefinition(parsed)
+    })
+  }
+
+  findById(characterId: CharacterId): CharacterDefinition | undefined {
+    return this.characters.find((c) => c.id === characterId)
+  }
+
+  findAll(): readonly CharacterDefinition[] {
+    return this.characters
+  }
+}

--- a/src/presentation/viewmodels/useRunViewModel.ts
+++ b/src/presentation/viewmodels/useRunViewModel.ts
@@ -4,7 +4,7 @@ import { castDraft } from 'immer'
 import type { Player } from '../../domain/entities/Player'
 import type { MapNode } from '../../domain/entities/MapNode'
 import { Seed } from '../../domain/value-objects/Seed'
-import { ScreenType } from '../../shared/types/ScreenType'
+import { type CharacterId, ScreenType } from '../../shared/types'
 import { createContainer } from '../../di/container'
 
 /**
@@ -71,7 +71,7 @@ export const useRunViewModel = create<RunState>()(
       // NOTE: execute は同期処理を前提としている。
       // 非同期化する場合は isStarting ガードと set() の順序を再設計すること。
       try {
-        const result = container.startRunUseCase.execute(characterId, seed)
+        const result = container.startRunUseCase.execute(characterId as CharacterId, seed)
 
         if (result.ok) {
           set((draft) => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,3 @@
-import { type CardId } from './types'
-
 // Hand & Deck
 export const MAX_HAND_SIZE = 10
 export const STARTING_DRAW_COUNT = 5
@@ -13,21 +11,6 @@ export const MAX_ENERGY = 3
 
 // HP
 export const MAX_HP_CAP = 999
-
-// Character starting HP
-// TODO: T111 CharacterRepository 実装後、この定数を削除して ICharacterRepository 経由に移行する。
-export const IRONCLAD_STARTING_HP = 80
-
-// Ironclad starting deck definition (card id → count)
-// TODO: T111 CharacterRepository 実装後、この定数を削除して ICharacterRepository 経由に移行する。
-export const IRONCLAD_STARTING_DECK: ReadonlyArray<{
-  readonly id: CardId
-  readonly count: number
-}> = [
-  { id: 'strike_r' as CardId, count: 5 },
-  { id: 'defend_r' as CardId, count: 4 },
-  { id: 'bash' as CardId, count: 1 },
-]
 
 // Gold
 export const STARTING_GOLD = 99

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@
 // Usage: `const id = 'strike' as CardId`
 
 export type CardId = string & { readonly _brand: 'CardId' }
+export type CharacterId = string & { readonly _brand: 'CharacterId' }
 export type RelicId = string & { readonly _brand: 'RelicId' }
 export type PotionId = string & { readonly _brand: 'PotionId' }
 export type EnemyId = string & { readonly _brand: 'EnemyId' }

--- a/tests/application/usecases/StartRunUseCase.test.ts
+++ b/tests/application/usecases/StartRunUseCase.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { StartRunUseCase } from '../../../src/application/usecases/StartRunUseCase'
 import { type ICardRepository } from '../../../src/domain/interfaces/ICardRepository'
+import { type ICharacterRepository } from '../../../src/domain/interfaces/ICharacterRepository'
+import { type CharacterDefinition } from '../../../src/domain/entities/CharacterDefinition'
 import { type Card } from '../../../src/domain/entities/Card'
 import { Seed } from '../../../src/domain/value-objects/Seed'
 import { CardType } from '../../../src/domain/enums/CardType'
 import { Rarity } from '../../../src/domain/enums/Rarity'
 import { TargetType } from '../../../src/domain/enums/TargetType'
-import { type CardId } from '../../../src/shared/types'
+import { type CardId, type CharacterId, type RelicId } from '../../../src/shared/types'
 import { MAP_FLOORS_PER_ACT } from '../../../src/shared/constants'
 
 // --- Test helpers ---
@@ -35,9 +37,37 @@ function buildCardRepo(overrides?: Partial<Record<string, Card | undefined>>): I
   }
   const cards = { ...defaultCards, ...overrides }
   return {
-    findById: vi.fn((id: string) => cards[id]),
+    findById: vi.fn((id: CardId) => cards[id]),
     findAll: vi.fn(() => []),
     findByRarity: vi.fn(() => []),
+  }
+}
+
+const IRONCLAD_DEFINITION: CharacterDefinition = {
+  id: 'ironclad' as CharacterId,
+  name: 'Ironclad',
+  startingHp: 80,
+  maxEnergy: 3,
+  startingDeck: [
+    { id: 'strike_r' as CardId, count: 5 },
+    { id: 'defend_r' as CardId, count: 4 },
+    { id: 'bash' as CardId, count: 1 },
+  ],
+  startingRelicId: 'burning_blood' as RelicId,
+}
+
+function buildCharacterRepo(
+  overrides?: Partial<Record<string, CharacterDefinition | undefined>>,
+): ICharacterRepository {
+  const defaultChars: Record<string, CharacterDefinition> = {
+    ironclad: IRONCLAD_DEFINITION,
+  }
+  const chars = { ...defaultChars, ...overrides }
+  return {
+    findById: vi.fn((id: CharacterId) => chars[id]),
+    findAll: vi.fn(() =>
+      Object.values(chars).filter((c): c is CharacterDefinition => c !== undefined),
+    ),
   }
 }
 
@@ -51,144 +81,146 @@ function createSeed(): Seed {
 
 describe('StartRunUseCase', () => {
   let cardRepo: ICardRepository
+  let characterRepo: ICharacterRepository
   let seed: Seed
   let usecase: StartRunUseCase
 
   beforeEach(() => {
     vi.clearAllMocks()
     cardRepo = buildCardRepo()
+    characterRepo = buildCharacterRepo()
     seed = createSeed()
-    usecase = new StartRunUseCase(cardRepo)
+    usecase = new StartRunUseCase(cardRepo, characterRepo)
   })
 
   describe('正常系 (ironclad)', () => {
     it('1. ok: true を返す', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       expect(result.ok).toBe(true)
     })
 
     it('2. player.id === "ironclad"', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.id).toBe('ironclad')
     })
 
     it('3. player.name === "Ironclad"', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.name).toBe('Ironclad')
     })
 
     it('4. player.health.current === 80 かつ player.health.max === 80', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.health.current).toBe(80)
       expect(result.value.player.health.max).toBe(80)
     })
 
     it('5. player.energy.current === 3 かつ player.energy.max === 3', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.energy.current).toBe(3)
       expect(result.value.player.energy.max).toBe(3)
     })
 
     it('6. player.gold.amount === 99', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.gold.amount).toBe(99)
     })
 
     it('7. player.block.value === 0', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.block.value).toBe(0)
     })
 
     it('8. player.deck.length === 10 (strike_r x5, defend_r x4, bash x1)', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.deck.length).toBe(10)
     })
 
     it('9. デッキに strike_r が5枚含まれる', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       const strikeCount = result.value.player.deck.filter((c) => c.id === 'strike_r').length
       expect(strikeCount).toBe(5)
     })
 
     it('10. デッキに defend_r が4枚含まれる', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       const defendCount = result.value.player.deck.filter((c) => c.id === 'defend_r').length
       expect(defendCount).toBe(4)
     })
 
     it('11. デッキに bash が1枚含まれる', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       const bashCount = result.value.player.deck.filter((c) => c.id === 'bash').length
       expect(bashCount).toBe(1)
     })
 
     it('12. player.hand が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.hand).toEqual([])
     })
 
     it('13. player.discardPile が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.discardPile).toEqual([])
     })
 
     it('14. player.exhaustPile が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.exhaustPile).toEqual([])
     })
 
     it('15. player.relics が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.relics).toEqual([])
     })
 
     it('16. player.powers が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.powers).toEqual([])
     })
 
     it('17. player.statusEffects が空配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.statusEffects).toEqual([])
     })
 
     it('18. player.potions が [null, null, null]', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.potions).toEqual([null, null, null])
     })
 
     it('19. player.maxPotionSlots === 3', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.player.maxPotionSlots).toBe(3)
     })
 
     it('20. map が MapNode[][] 型の配列', () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(Array.isArray(result.value.map)).toBe(true)
       expect(Array.isArray(result.value.map[0])).toBe(true)
     })
 
     it(`21. map.length === ${MAP_FLOORS_PER_ACT} (MAP_FLOORS_PER_ACT)`, () => {
-      const result = usecase.execute('ironclad', seed)
+      const result = usecase.execute('ironclad' as CharacterId, seed)
       if (!result.ok) throw new Error(result.error)
       expect(result.value.map.length).toBe(MAP_FLOORS_PER_ACT)
     })
@@ -196,14 +228,14 @@ describe('StartRunUseCase', () => {
 
   describe('異常系', () => {
     it('22. 未知のcharacterId ("silent") で err("unknown character") を返す', () => {
-      const result = usecase.execute('silent', seed)
+      const result = usecase.execute('silent' as CharacterId, seed)
       expect(result.ok).toBe(false)
       if (result.ok) throw new Error('Expected error')
       expect(result.error).toBe('unknown character')
     })
 
     it('22b. 空文字列 characterId で err("unknown character") を返す', () => {
-      const result = usecase.execute('', seed)
+      const result = usecase.execute('' as CharacterId, seed)
       expect(result.ok).toBe(false)
       if (result.ok) throw new Error('Expected error')
       expect(result.error).toBe('unknown character')
@@ -211,8 +243,8 @@ describe('StartRunUseCase', () => {
 
     it('23. findById("strike_r") が undefined の場合、err を返す', () => {
       const repoWithMissingStrike = buildCardRepo({ strike_r: undefined })
-      const uc = new StartRunUseCase(repoWithMissingStrike)
-      const result = uc.execute('ironclad', seed)
+      const uc = new StartRunUseCase(repoWithMissingStrike, characterRepo)
+      const result = uc.execute('ironclad' as CharacterId, seed)
       expect(result.ok).toBe(false)
       if (result.ok) throw new Error('Expected error')
       expect(result.error).toBe('Card not found: strike_r')
@@ -220,8 +252,8 @@ describe('StartRunUseCase', () => {
 
     it('24. findById("defend_r") が undefined の場合、err を返す', () => {
       const repoWithMissingDefend = buildCardRepo({ defend_r: undefined })
-      const uc = new StartRunUseCase(repoWithMissingDefend)
-      const result = uc.execute('ironclad', seed)
+      const uc = new StartRunUseCase(repoWithMissingDefend, characterRepo)
+      const result = uc.execute('ironclad' as CharacterId, seed)
       expect(result.ok).toBe(false)
       if (result.ok) throw new Error('Expected error')
       expect(result.error).toBe('Card not found: defend_r')
@@ -229,8 +261,8 @@ describe('StartRunUseCase', () => {
 
     it('25. findById("bash") が undefined の場合、err を返す', () => {
       const repoWithMissingBash = buildCardRepo({ bash: undefined })
-      const uc = new StartRunUseCase(repoWithMissingBash)
-      const result = uc.execute('ironclad', seed)
+      const uc = new StartRunUseCase(repoWithMissingBash, characterRepo)
+      const result = uc.execute('ironclad' as CharacterId, seed)
       expect(result.ok).toBe(false)
       if (result.ok) throw new Error('Expected error')
       expect(result.error).toBe('Card not found: bash')

--- a/tests/infrastructure/repositories/JsonCardRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonCardRepository.test.ts
@@ -3,6 +3,7 @@ import { JsonCardRepository } from '../../../src/infrastructure/repositories/Jso
 import { CardType } from '../../../src/domain/enums/CardType'
 import { Rarity } from '../../../src/domain/enums/Rarity'
 import { TargetType } from '../../../src/domain/enums/TargetType'
+import { type CardId } from '../../../src/shared/types'
 
 describe('JsonCardRepository', () => {
   // 全テストで同一の read-only リポジトリを共有（毎回パースは不要）
@@ -39,18 +40,20 @@ describe('JsonCardRepository', () => {
       }
     })
 
-    it.todo('target を持たない effect は target フィールドを含まない（target なし effect のデータ追加時に実装）')
+    it.todo(
+      'target を持たない effect は target フィールドを含まない（target なし effect のデータ追加時に実装）',
+    )
   })
 
   describe('findById', () => {
     it('存在するIDでカードを返す', () => {
-      const card = repository.findById('strike_r')
+      const card = repository.findById('strike_r' as CardId)
       expect(card).toBeDefined()
       expect(card?.id).toBe('strike_r')
     })
 
     it('strike_r のフィールドが正しくマッピングされている', () => {
-      const card = repository.findById('strike_r')
+      const card = repository.findById('strike_r' as CardId)
       expect(card).toBeDefined()
       if (!card) return
 
@@ -64,7 +67,7 @@ describe('JsonCardRepository', () => {
     })
 
     it('strike_r の effects が正しくマッピングされている', () => {
-      const card = repository.findById('strike_r')
+      const card = repository.findById('strike_r' as CardId)
       expect(card?.effects).toHaveLength(1)
       expect(card?.effects[0]).toEqual({
         type: 'damage',
@@ -74,19 +77,19 @@ describe('JsonCardRepository', () => {
     })
 
     it('bash の複数エフェクトが正しくマッピングされている', () => {
-      const card = repository.findById('bash')
+      const card = repository.findById('bash' as CardId)
       expect(card?.effects).toHaveLength(2)
       expect(card?.effects[0]).toEqual({ type: 'damage', value: 8, target: 'single_enemy' })
       expect(card?.effects[1]).toEqual({ type: 'vulnerable', value: 2, target: 'single_enemy' })
     })
 
     it('存在しないIDで undefined を返す', () => {
-      const card = repository.findById('nonexistent')
+      const card = repository.findById('nonexistent' as CardId)
       expect(card).toBeUndefined()
     })
 
     it('空文字IDで undefined を返す', () => {
-      const card = repository.findById('')
+      const card = repository.findById('' as CardId)
       expect(card).toBeUndefined()
     })
   })

--- a/tests/infrastructure/repositories/JsonCharacterRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonCharacterRepository.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { JsonCharacterRepository } from '../../../src/infrastructure/repositories/JsonCharacterRepository'
+import { type CharacterId } from '../../../src/shared/types'
+
+describe('JsonCharacterRepository', () => {
+  let repository: JsonCharacterRepository
+
+  beforeAll(() => {
+    repository = new JsonCharacterRepository()
+  })
+
+  // -------------------------------------------------------------------------
+  // No.26: Factoryパターン・正常生成
+  // -------------------------------------------------------------------------
+  describe('constructor', () => {
+    it('有効な JSON ファイルでインスタンスを生成できる', () => {
+      expect(() => new JsonCharacterRepository()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作 / No.24: リポジトリ・データスキーマ検証
+  // -------------------------------------------------------------------------
+  describe('findAll', () => {
+    it('ironclad と silent の 2 キャラクターを返す', () => {
+      const characters = repository.findAll()
+      expect(characters).toHaveLength(2)
+    })
+
+    it('CharacterDefinition の必須フィールドが全て存在し型が正しい', () => {
+      const characters = repository.findAll()
+      for (const character of characters) {
+        expect(typeof character.id).toBe('string')
+        expect(character.id.length).toBeGreaterThan(0)
+
+        expect(typeof character.name).toBe('string')
+        expect(character.name.length).toBeGreaterThan(0)
+
+        expect(typeof character.startingHp).toBe('number')
+        expect(character.startingHp).toBeGreaterThan(0)
+
+        expect(typeof character.maxEnergy).toBe('number')
+        expect(character.maxEnergy).toBeGreaterThan(0)
+
+        expect(Array.isArray(character.startingDeck)).toBe(true)
+        expect(character.startingDeck.length).toBeGreaterThan(0)
+
+        for (const entry of character.startingDeck) {
+          expect(typeof entry.id).toBe('string')
+          expect(entry.id.length).toBeGreaterThan(0)
+          expect(typeof entry.count).toBe('number')
+          expect(entry.count).toBeGreaterThan(0)
+        }
+
+        expect(typeof character.startingRelicId).toBe('string')
+        expect(character.startingRelicId.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作
+  // -------------------------------------------------------------------------
+  describe('findById', () => {
+    it('存在するIDでCharacterDefinitionを返す', () => {
+      const character = repository.findById('ironclad' as CharacterId)
+      expect(character).toBeDefined()
+      expect(character?.id).toBe('ironclad')
+    })
+
+    // AC4: 取得したキャラクター定義に初期デッキ・初期HP・開始レリック・エネルギー上限が含まれること
+    describe('ironclad のフィールドが正しくマッピングされている', () => {
+      it('基本フィールド（name / startingHp / maxEnergy）が正しい', () => {
+        const character = repository.findById('ironclad' as CharacterId)
+        expect(character).toBeDefined()
+        if (!character) return
+
+        expect(character.name).toBe('Ironclad')
+        expect(character.startingHp).toBe(80)
+        expect(character.maxEnergy).toBe(3)
+      })
+
+      it('startingRelicId が正しい', () => {
+        const character = repository.findById('ironclad' as CharacterId)
+        expect(character?.startingRelicId).toBe('burning_blood')
+      })
+
+      it('startingDeck が正しくマッピングされている', () => {
+        const character = repository.findById('ironclad' as CharacterId)
+        expect(character).toBeDefined()
+        if (!character) return
+
+        expect(character.startingDeck).toHaveLength(3)
+        expect(character.startingDeck).toContainEqual({ id: 'strike_r', count: 5 })
+        expect(character.startingDeck).toContainEqual({ id: 'defend_r', count: 4 })
+        expect(character.startingDeck).toContainEqual({ id: 'bash', count: 1 })
+      })
+    })
+
+    describe('silent のフィールドが正しくマッピングされている', () => {
+      it('基本フィールド（name / startingHp / maxEnergy）が正しい', () => {
+        const character = repository.findById('silent' as CharacterId)
+        expect(character).toBeDefined()
+        if (!character) return
+
+        expect(character.name).toBe('Silent')
+        expect(character.startingHp).toBe(70)
+        expect(character.maxEnergy).toBe(3)
+      })
+
+      it('startingRelicId が正しい', () => {
+        const character = repository.findById('silent' as CharacterId)
+        expect(character?.startingRelicId).toBe('ring_of_the_snake')
+      })
+
+      it('startingDeck が正しくマッピングされている', () => {
+        const character = repository.findById('silent' as CharacterId)
+        expect(character).toBeDefined()
+        if (!character) return
+
+        expect(character.startingDeck).toHaveLength(2)
+        expect(character.startingDeck).toContainEqual({ id: 'strike_g', count: 6 })
+        expect(character.startingDeck).toContainEqual({ id: 'defend_g', count: 6 })
+      })
+    })
+
+    // -------------------------------------------------------------------------
+    // No.08: 異常系・存在しないキー（AC2）
+    // -------------------------------------------------------------------------
+    it('存在しないIDで undefined を返す', () => {
+      const character = repository.findById('nonexistent' as CharacterId)
+      expect(character).toBeUndefined()
+    })
+
+    it('空文字IDで undefined を返す', () => {
+      const character = repository.findById('' as CharacterId)
+      expect(character).toBeUndefined()
+    })
+
+    it('大文字・小文字が異なるIDで undefined を返す（大文字小文字厳密一致）', () => {
+      const character = repository.findById('Ironclad' as CharacterId)
+      expect(character).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // AC3: 依存方向ルール検証（No.27: Factoryパターン・異常生成）
+  // -------------------------------------------------------------------------
+  describe('依存方向・スキーマ検証', () => {
+    it('JsonCharacterRepository は ICharacterRepository を実装している', () => {
+      // findById / findAll の両メソッドを持つことで interface 実装を確認する
+      expect(typeof repository.findById).toBe('function')
+      expect(typeof repository.findAll).toBe('function')
+    })
+
+    it('findAll の結果は findById の部分集合である', () => {
+      const all = repository.findAll()
+      for (const character of all) {
+        const found = repository.findById(character.id)
+        expect(found).toBeDefined()
+        expect(found?.id).toBe(character.id)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `CharacterDefinition` 型・`ICharacterRepository`・`JsonCharacterRepository` を新規追加
- `CharacterId` ブランド型を `shared/types` に追加（他IDとの誤混在を型レベルで防止）
- Ironclad・Silent のキャラクターマスターデータ（JSON）を追加
- `StartRunUseCase` を `ICharacterRepository` 経由に移行（hardcoded `'ironclad'` チェック削除）
- `ICardRepository.findById` の引数を `string` → `CardId` に統一（#134 archer review 指摘対応）
- `StartRunUseCase.execute` の引数を `CharacterId` に変更（境界キャストを presentation 層へ移動）
- `shared/constants.ts` から `IRONCLAD_STARTING_HP` / `IRONCLAD_STARTING_DECK` を削除

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] `tests/infrastructure/repositories/JsonCharacterRepository.test.ts` 全テスト通過
- [ ] `tests/application/usecases/StartRunUseCase.test.ts` 全テスト通過（リファクタリング後も同一挙動）
- [ ] `tests/infrastructure/repositories/JsonCardRepository.test.ts` 全テスト通過（CardId 型変更対応）

Closes #134