### PR TITLE
feat: T133 イベントリポジトリ実装（JsonEventRepository）

### DIFF
--- a/src/domain/entities/EventDefinition.ts
+++ b/src/domain/entities/EventDefinition.ts
@@ -1,0 +1,46 @@
+import { type CardId, type EventId, type RelicId } from '../../shared/types'
+
+/**
+ * イベントアウトカム（discriminated union）
+ *
+ * イベント選択肢を選んだ際の結果。kind によって必須フィールドが異なる。
+ * - 数値効果（gain_hp / lose_hp / gain_gold / lose_gold）: value 必須
+ * - カード操作（add_card）: cardId 必須
+ * - カード除去（remove_card）: cardId 任意（省略時はプレイヤーが選択）
+ * - レリック取得（gain_relic）: relicId 必須
+ * - 何もなし（nothing）: 追加フィールドなし
+ */
+export type EventOutcome =
+  | { readonly kind: 'gain_hp'; readonly value: number }
+  | { readonly kind: 'lose_hp'; readonly value: number }
+  | { readonly kind: 'gain_gold'; readonly value: number }
+  | { readonly kind: 'lose_gold'; readonly value: number }
+  | { readonly kind: 'add_card'; readonly cardId: CardId }
+  | { readonly kind: 'remove_card'; readonly cardId?: CardId }
+  | { readonly kind: 'gain_relic'; readonly relicId: RelicId }
+  | { readonly kind: 'nothing' }
+
+/**
+ * イベント選択肢
+ *
+ * イベント画面でプレイヤーが選べる選択肢と、選んだ際の結果の一覧。
+ * outcomes は全件・宣言順に適用される。
+ */
+export type EventChoice = {
+  readonly text: string
+  /** 選択時に全件・宣言順に適用されるアウトカムのリスト */
+  readonly outcomes: ReadonlyArray<EventOutcome>
+}
+
+/**
+ * イベント定義
+ *
+ * マップ上のイベントノードで発生するイベントのマスターデータ。
+ * 参照可能な層: shared/types のみ（domain ロジック依存ゼロ）
+ */
+export type EventDefinition = {
+  readonly id: EventId
+  readonly name: string
+  readonly description: string
+  readonly choices: ReadonlyArray<EventChoice>
+}

--- a/src/domain/interfaces/IEventRepository.ts
+++ b/src/domain/interfaces/IEventRepository.ts
@@ -1,0 +1,13 @@
+import { type EventId } from '../../shared/types'
+import { type EventDefinition } from '../entities/EventDefinition'
+
+/**
+ * イベントリポジトリインターフェース
+ *
+ * イベントマスターデータ取得の契約。
+ * 参照可能な層: domain/entities のみ
+ */
+export interface IEventRepository {
+  findById(eventId: EventId): EventDefinition | undefined
+  findAll(): ReadonlyArray<EventDefinition>
+}

--- a/src/infrastructure/data/events.json
+++ b/src/infrastructure/data/events.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "the_cleric",
+    "name": "The Cleric",
+    "description": "A friendly cleric offers to assist you on your journey.",
+    "choices": [
+      {
+        "text": "Heal",
+        "outcomes": [
+          { "kind": "gain_hp", "value": 5 },
+          { "kind": "lose_gold", "value": 35 }
+        ]
+      },
+      {
+        "text": "Leave",
+        "outcomes": [
+          { "kind": "nothing" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "dead_adventurer",
+    "name": "Dead Adventurer",
+    "description": "You come across a fallen adventurer. Their belongings remain.",
+    "choices": [
+      {
+        "text": "Search Body",
+        "outcomes": [
+          { "kind": "gain_gold", "value": 25 },
+          { "kind": "add_card", "card_id": "strike_r" }
+        ]
+      },
+      {
+        "text": "Leave",
+        "outcomes": [
+          { "kind": "nothing" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "golden_wing",
+    "name": "Golden Wing",
+    "description": "A majestic golden-winged creature lands before you and speaks.",
+    "choices": [
+      {
+        "text": "Take Relic",
+        "outcomes": [
+          { "kind": "gain_relic", "relic_id": "akabeko" },
+          { "kind": "lose_hp", "value": 10 }
+        ]
+      },
+      {
+        "text": "Take Gold",
+        "outcomes": [
+          { "kind": "gain_gold", "value": 50 }
+        ]
+      }
+    ]
+  }
+]

--- a/src/infrastructure/data/schemas.ts
+++ b/src/infrastructure/data/schemas.ts
@@ -115,3 +115,53 @@ export const CharacterSchema = z.object({
 })
 
 export type CharacterRaw = z.infer<typeof CharacterSchema>
+
+/**
+ * イベントアウトカムのraw形状スキーマ（discriminated union）
+ *
+ * kind ごとに必須フィールドを明示することで、スキーマと domain 型の二重管理を排除。
+ * - 数値効果: value 必須
+ * - カード操作: card_id 必須（remove_card は任意）
+ * - レリック取得: relic_id 必須
+ * - nothing: 追加フィールドなし
+ */
+export const EventOutcomeSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('gain_hp'), value: z.number() }),
+  z.object({ kind: z.literal('lose_hp'), value: z.number() }),
+  z.object({ kind: z.literal('gain_gold'), value: z.number() }),
+  z.object({ kind: z.literal('lose_gold'), value: z.number() }),
+  z.object({ kind: z.literal('add_card'), card_id: z.string().min(1) }),
+  z.object({ kind: z.literal('remove_card'), card_id: z.string().optional() }),
+  z.object({ kind: z.literal('gain_relic'), relic_id: z.string().min(1) }),
+  z.object({ kind: z.literal('nothing') }),
+])
+
+export type EventOutcomeRaw = z.infer<typeof EventOutcomeSchema>
+
+/**
+ * イベント選択肢のraw形状スキーマ
+ *
+ * イベント画面でプレイヤーが選べる選択肢のJSONraw形状。
+ */
+export const EventChoiceSchema = z.object({
+  text: z.string().min(1),
+  outcomes: z.array(EventOutcomeSchema).min(1),
+})
+
+export type EventChoiceRaw = z.infer<typeof EventChoiceSchema>
+
+/**
+ * イベントJSONのraw形状スキーマ
+ *
+ * マップイベントノードのマスターデータのJSONraw形状。
+ * フィールド名はsnake_case（JSONのraw形状）。ドメイン型のcamelCaseへの
+ * 変換はリポジトリのマッパー関数で行う。
+ */
+export const EventSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  choices: z.array(EventChoiceSchema).min(1),
+})
+
+export type EventRaw = z.infer<typeof EventSchema>

--- a/src/infrastructure/repositories/JsonCardRepository.ts
+++ b/src/infrastructure/repositories/JsonCardRepository.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { type Card } from '../../domain/entities/Card'
 import { Rarity } from '../../domain/enums/Rarity'
 import { type ICardRepository } from '../../domain/interfaces/ICardRepository'
@@ -54,11 +55,7 @@ export class JsonCardRepository implements ICardRepository {
   private readonly cards: readonly Card[]
 
   constructor() {
-    const rawCards = ironcladCards as unknown[]
-    this.cards = rawCards.map((raw) => {
-      const parsed = CardSchema.parse(raw)
-      return toCardEntity(parsed)
-    })
+    this.cards = z.array(CardSchema).parse(ironcladCards).map(toCardEntity)
   }
 
   findById(id: CardId): Card | undefined {

--- a/src/infrastructure/repositories/JsonCharacterRepository.ts
+++ b/src/infrastructure/repositories/JsonCharacterRepository.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import {
   type CharacterDefinition,
   type StarterDeckEntry,
@@ -45,11 +46,10 @@ export class JsonCharacterRepository implements ICharacterRepository {
   private readonly characters: readonly CharacterDefinition[]
 
   constructor() {
-    const rawData: unknown[] = [ironcladData, silentData]
-    this.characters = rawData.map((raw) => {
-      const parsed = CharacterSchema.parse(raw)
-      return toCharacterDefinition(parsed)
-    })
+    this.characters = z
+      .array(CharacterSchema)
+      .parse([ironcladData, silentData])
+      .map(toCharacterDefinition)
   }
 
   findById(characterId: CharacterId): CharacterDefinition | undefined {

--- a/src/infrastructure/repositories/JsonEventRepository.ts
+++ b/src/infrastructure/repositories/JsonEventRepository.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+import {
+  type EventDefinition,
+  type EventChoice,
+  type EventOutcome,
+} from '../../domain/entities/EventDefinition'
+import { type IEventRepository } from '../../domain/interfaces/IEventRepository'
+import { type CardId, type EventId, type RelicId } from '../../shared/types'
+import { EventSchema, type EventChoiceRaw, type EventOutcomeRaw } from '../data/schemas'
+import eventsData from '../data/events.json'
+
+/**
+ * EventOutcomeRaw（snake_case）→ EventOutcome（camelCase）へのマッパー
+ *
+ * switch文により kind ごとのフィールドマッピングを型安全に記述する。
+ * TypeScript の exhaustiveness check により、新しい kind 追加時にコンパイルエラーで検出できる。
+ */
+function toEventOutcome(raw: EventOutcomeRaw): EventOutcome {
+  switch (raw.kind) {
+    case 'gain_hp':
+      return { kind: 'gain_hp', value: raw.value }
+    case 'lose_hp':
+      return { kind: 'lose_hp', value: raw.value }
+    case 'gain_gold':
+      return { kind: 'gain_gold', value: raw.value }
+    case 'lose_gold':
+      return { kind: 'lose_gold', value: raw.value }
+    case 'add_card':
+      return { kind: 'add_card', cardId: raw.card_id as CardId }
+    case 'remove_card':
+      return {
+        kind: 'remove_card',
+        ...(raw.card_id !== undefined ? { cardId: raw.card_id as CardId } : {}),
+      }
+    case 'gain_relic':
+      return { kind: 'gain_relic', relicId: raw.relic_id as RelicId }
+    case 'nothing':
+      return { kind: 'nothing' }
+  }
+}
+
+/**
+ * EventChoiceRaw（snake_case）→ EventChoice（camelCase）へのマッパー
+ */
+function toEventChoice(raw: EventChoiceRaw): EventChoice {
+  return {
+    text: raw.text,
+    outcomes: raw.outcomes.map(toEventOutcome),
+  }
+}
+
+/**
+ * JSONファイルベースのイベントリポジトリ
+ *
+ * JSONファイルを z.array(EventSchema).parse() で一括検証し、EventDefinitionとして返す。
+ * 参照可能な層: domain/interfaces, domain/entities, shared/types,
+ *               infrastructure/data
+ */
+export class JsonEventRepository implements IEventRepository {
+  private readonly events: ReadonlyArray<EventDefinition>
+
+  constructor() {
+    const parsed = z.array(EventSchema).parse(eventsData)
+    this.events = parsed.map((raw) => ({
+      id: raw.id as EventId,
+      name: raw.name,
+      description: raw.description,
+      choices: raw.choices.map(toEventChoice),
+    }))
+  }
+
+  findById(eventId: EventId): EventDefinition | undefined {
+    return this.events.find((e) => e.id === eventId)
+  }
+
+  findAll(): ReadonlyArray<EventDefinition> {
+    return this.events
+  }
+}

--- a/src/infrastructure/repositories/JsonRelicRepository.ts
+++ b/src/infrastructure/repositories/JsonRelicRepository.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { type GameEvent, type Relic, type StateWithPlayer } from '../../domain/entities/Relic'
 import { Rarity } from '../../domain/enums/Rarity'
 import { type IRelicRepository } from '../../domain/interfaces/IRelicRepository'
@@ -36,11 +37,7 @@ export class JsonRelicRepository implements IRelicRepository {
   private readonly relics: readonly Relic[]
 
   constructor() {
-    const rawRelics = ironcladRelics as unknown[]
-    this.relics = rawRelics.map((raw) => {
-      const parsed = RelicSchema.parse(raw)
-      return toRelicEntity(parsed)
-    })
+    this.relics = z.array(RelicSchema).parse(ironcladRelics).map(toRelicEntity)
   }
 
   findById(id: string): Relic | undefined {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -13,6 +13,8 @@ export type EffectId = string & { readonly _brand: 'EffectId' }
 export type StatusEffectId = string & { readonly _brand: 'StatusEffectId' }
 // PowerId: 筋力・アーティファクト等のパワー識別子（T16）
 export type PowerId = string & { readonly _brand: 'PowerId' }
+// EventId: マップイベントノードで発生するイベントの識別子（T133）
+export type EventId = string & { readonly _brand: 'EventId' }
 
 // --- Target (discriminated union) ---
 // Represents the runtime target of an animation or effect.

--- a/tests/infrastructure/repositories/JsonEventRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonEventRepository.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { JsonEventRepository } from '../../../src/infrastructure/repositories/JsonEventRepository'
+import { type EventId } from '../../../src/shared/types'
+
+describe('JsonEventRepository', () => {
+  let repository: JsonEventRepository
+
+  beforeAll(() => {
+    repository = new JsonEventRepository()
+  })
+
+  // -------------------------------------------------------------------------
+  // No.26: Factoryパターン・正常生成
+  // -------------------------------------------------------------------------
+  describe('constructor', () => {
+    it('有効な JSON ファイルでインスタンスを生成できる', () => {
+      expect(() => new JsonEventRepository()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作 / No.24: データスキーマ検証
+  // -------------------------------------------------------------------------
+  describe('findAll', () => {
+    // AC1: イベントリポジトリからイベントデータを取得できること
+    it('3件のイベントを返す', () => {
+      const events = repository.findAll()
+      expect(events).toHaveLength(3)
+    })
+
+    // AC2: イベントデータに選択肢と結果が含まれること
+    it('EventDefinition の必須フィールドが全て存在し型が正しい', () => {
+      const events = repository.findAll()
+      for (const event of events) {
+        expect(typeof event.id).toBe('string')
+        expect(event.id.length).toBeGreaterThan(0)
+
+        expect(typeof event.name).toBe('string')
+        expect(event.name.length).toBeGreaterThan(0)
+
+        expect(typeof event.description).toBe('string')
+        expect(event.description.length).toBeGreaterThan(0)
+
+        expect(Array.isArray(event.choices)).toBe(true)
+        expect(event.choices.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('各 EventChoice に text と outcomes が含まれる', () => {
+      const events = repository.findAll()
+      for (const event of events) {
+        for (const choice of event.choices) {
+          expect(typeof choice.text).toBe('string')
+          expect(choice.text.length).toBeGreaterThan(0)
+          expect(Array.isArray(choice.outcomes)).toBe(true)
+          expect(choice.outcomes.length).toBeGreaterThan(0)
+        }
+      }
+    })
+
+    it('各 EventOutcome の kind が文字列である', () => {
+      const events = repository.findAll()
+      for (const event of events) {
+        for (const choice of event.choices) {
+          for (const outcome of choice.outcomes) {
+            expect(typeof outcome.kind).toBe('string')
+          }
+        }
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作
+  // -------------------------------------------------------------------------
+  describe('findById', () => {
+    it('存在するIDで EventDefinition を返す', () => {
+      const event = repository.findById('the_cleric' as EventId)
+      expect(event).toBeDefined()
+      expect(event?.id).toBe('the_cleric')
+    })
+
+    // AC2: 特定イベントの具体値検証
+    describe('the_cleric のフィールドが正しくマッピングされている', () => {
+      it('基本フィールド（name / description）が正しい', () => {
+        const event = repository.findById('the_cleric' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        expect(event.name).toBe('The Cleric')
+        expect(typeof event.description).toBe('string')
+        expect(event.description.length).toBeGreaterThan(0)
+      })
+
+      it('choices が2件である', () => {
+        const event = repository.findById('the_cleric' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        expect(event.choices).toHaveLength(2)
+      })
+
+      it('Heal 選択肢の outcome に gain_hp が含まれる', () => {
+        const event = repository.findById('the_cleric' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        const healChoice = event.choices.find((c) => c.text === 'Heal')
+        expect(healChoice).toBeDefined()
+        if (!healChoice) return
+
+        const gainHpOutcome = healChoice.outcomes.find((o) => o.kind === 'gain_hp')
+        expect(gainHpOutcome).toBeDefined()
+        if (!gainHpOutcome || gainHpOutcome.kind !== 'gain_hp') return
+        expect(typeof gainHpOutcome.value).toBe('number')
+        expect(gainHpOutcome.value).toBeGreaterThan(0)
+      })
+
+      it('Heal 選択肢の outcome に lose_gold が含まれる', () => {
+        const event = repository.findById('the_cleric' as EventId)
+        if (!event) return
+
+        const healChoice = event.choices.find((c) => c.text === 'Heal')
+        if (!healChoice) return
+
+        const loseGoldOutcome = healChoice.outcomes.find((o) => o.kind === 'lose_gold')
+        expect(loseGoldOutcome).toBeDefined()
+        if (!loseGoldOutcome || loseGoldOutcome.kind !== 'lose_gold') return
+        expect(loseGoldOutcome.value).toBeGreaterThan(0)
+      })
+
+      it('Leave 選択肢の outcome に nothing が含まれる', () => {
+        const event = repository.findById('the_cleric' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        const leaveChoice = event.choices.find((c) => c.text === 'Leave')
+        expect(leaveChoice).toBeDefined()
+        if (!leaveChoice) return
+
+        const nothingOutcome = leaveChoice.outcomes.find((o) => o.kind === 'nothing')
+        expect(nothingOutcome).toBeDefined()
+      })
+    })
+
+    describe('dead_adventurer のフィールドが正しくマッピングされている', () => {
+      it('Search Body 選択肢に gain_gold と add_card が含まれる', () => {
+        const event = repository.findById('dead_adventurer' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        const searchChoice = event.choices.find((c) => c.text === 'Search Body')
+        expect(searchChoice).toBeDefined()
+        if (!searchChoice) return
+
+        expect(searchChoice.outcomes.some((o) => o.kind === 'gain_gold')).toBe(true)
+        expect(searchChoice.outcomes.some((o) => o.kind === 'add_card')).toBe(true)
+      })
+
+      it('add_card の outcome に cardId が含まれる', () => {
+        const event = repository.findById('dead_adventurer' as EventId)
+        if (!event) return
+
+        const searchChoice = event.choices.find((c) => c.text === 'Search Body')
+        if (!searchChoice) return
+
+        const addCardOutcome = searchChoice.outcomes.find((o) => o.kind === 'add_card')
+        expect(addCardOutcome).toBeDefined()
+        if (!addCardOutcome || addCardOutcome.kind !== 'add_card') return
+        expect(typeof addCardOutcome.cardId).toBe('string')
+        expect(addCardOutcome.cardId.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('golden_wing のフィールドが正しくマッピングされている', () => {
+      it('Take Relic 選択肢に gain_relic が含まれる', () => {
+        const event = repository.findById('golden_wing' as EventId)
+        expect(event).toBeDefined()
+        if (!event) return
+
+        const takeRelicChoice = event.choices.find((c) => c.text === 'Take Relic')
+        expect(takeRelicChoice).toBeDefined()
+        if (!takeRelicChoice) return
+
+        const gainRelicOutcome = takeRelicChoice.outcomes.find((o) => o.kind === 'gain_relic')
+        expect(gainRelicOutcome).toBeDefined()
+        if (!gainRelicOutcome || gainRelicOutcome.kind !== 'gain_relic') return
+        expect(typeof gainRelicOutcome.relicId).toBe('string')
+        expect(gainRelicOutcome.relicId.length).toBeGreaterThan(0)
+      })
+
+      it('Take Relic 選択肢に lose_hp が含まれる', () => {
+        const event = repository.findById('golden_wing' as EventId)
+        if (!event) return
+
+        const takeRelicChoice = event.choices.find((c) => c.text === 'Take Relic')
+        if (!takeRelicChoice) return
+
+        const loseHpOutcome = takeRelicChoice.outcomes.find((o) => o.kind === 'lose_hp')
+        expect(loseHpOutcome).toBeDefined()
+        if (!loseHpOutcome || loseHpOutcome.kind !== 'lose_hp') return
+        expect(loseHpOutcome.value).toBeGreaterThan(0)
+      })
+    })
+
+    // -------------------------------------------------------------------------
+    // No.08: 異常系・存在しないキー参照
+    // -------------------------------------------------------------------------
+    it('存在しないIDで undefined を返す', () => {
+      const event = repository.findById('nonexistent' as EventId)
+      expect(event).toBeUndefined()
+    })
+
+    it('空文字IDで undefined を返す', () => {
+      const event = repository.findById('' as EventId)
+      expect(event).toBeUndefined()
+    })
+
+    it('大文字・小文字が異なるIDで undefined を返す（大文字小文字厳密一致）', () => {
+      const event = repository.findById('The_Cleric' as EventId)
+      expect(event).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.22: リポジトリパターン保存と再取得の一貫性
+  // IEventRepository interface実装確認
+  // -------------------------------------------------------------------------
+  describe('IEventRepository 実装確認・一貫性', () => {
+    it('JsonEventRepository は IEventRepository を実装している', () => {
+      expect(typeof repository.findById).toBe('function')
+      expect(typeof repository.findAll).toBe('function')
+    })
+
+    it('findAll の結果は findById の部分集合である', () => {
+      const all = repository.findAll()
+      for (const event of all) {
+        const found = repository.findById(event.id)
+        expect(found).toBeDefined()
+        expect(found?.id).toBe(event.id)
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.27: Factoryパターン・異常生成（AC3: クラッシュしない）
+  // -------------------------------------------------------------------------
+  describe('不正データのハンドリング（EventSchema）', () => {
+    it('必須フィールドが欠けた不正オブジェクトを渡すと ZodError をthrowする', async () => {
+      const { EventSchema } = await import('../../../src/infrastructure/data/schemas')
+      expect(() => EventSchema.parse({ id: 'bad' })).toThrow()
+    })
+
+    it('EventSchema.safeParse は不正データでcrashせず success: false を返す', async () => {
+      const { EventSchema } = await import('../../../src/infrastructure/data/schemas')
+      const result = EventSchema.safeParse({ id: 'bad', choices: 'not_an_array' })
+      expect(result.success).toBe(false)
+    })
+
+    it('choices が空配列のデータは ZodError をthrowする', async () => {
+      const { EventSchema } = await import('../../../src/infrastructure/data/schemas')
+      expect(() =>
+        EventSchema.parse({
+          id: 'empty_choices',
+          name: 'Empty',
+          description: 'No choices',
+          choices: [],
+        }),
+      ).toThrow()
+    })
+
+    it('outcomes が空配列の選択肢は ZodError をthrowする', async () => {
+      const { EventSchema } = await import('../../../src/infrastructure/data/schemas')
+      expect(() =>
+        EventSchema.parse({
+          id: 'empty_outcomes',
+          name: 'Empty',
+          description: 'No outcomes',
+          choices: [{ text: 'Choice', outcomes: [] }],
+        }),
+      ).toThrow()
+    })
+  })
+})

--- a/tests/infrastructure/repositories/JsonEventRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonEventRepository.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, assert } from 'vitest'
 import { JsonEventRepository } from '../../../src/infrastructure/repositories/JsonEventRepository'
 import { type EventId } from '../../../src/shared/types'
 
@@ -84,8 +84,7 @@ describe('JsonEventRepository', () => {
     describe('the_cleric のフィールドが正しくマッピングされている', () => {
       it('基本フィールド（name / description）が正しい', () => {
         const event = repository.findById('the_cleric' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         expect(event.name).toBe('The Cleric')
         expect(typeof event.description).toBe('string')
@@ -94,49 +93,42 @@ describe('JsonEventRepository', () => {
 
       it('choices が2件である', () => {
         const event = repository.findById('the_cleric' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         expect(event.choices).toHaveLength(2)
       })
 
       it('Heal 選択肢の outcome に gain_hp が含まれる', () => {
         const event = repository.findById('the_cleric' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         const healChoice = event.choices.find((c) => c.text === 'Heal')
-        expect(healChoice).toBeDefined()
-        if (!healChoice) return
+        assert(healChoice !== undefined)
 
         const gainHpOutcome = healChoice.outcomes.find((o) => o.kind === 'gain_hp')
-        expect(gainHpOutcome).toBeDefined()
-        if (!gainHpOutcome || gainHpOutcome.kind !== 'gain_hp') return
+        assert(gainHpOutcome !== undefined && gainHpOutcome.kind === 'gain_hp')
         expect(typeof gainHpOutcome.value).toBe('number')
         expect(gainHpOutcome.value).toBeGreaterThan(0)
       })
 
       it('Heal 選択肢の outcome に lose_gold が含まれる', () => {
         const event = repository.findById('the_cleric' as EventId)
-        if (!event) return
+        assert(event !== undefined)
 
         const healChoice = event.choices.find((c) => c.text === 'Heal')
-        if (!healChoice) return
+        assert(healChoice !== undefined)
 
         const loseGoldOutcome = healChoice.outcomes.find((o) => o.kind === 'lose_gold')
-        expect(loseGoldOutcome).toBeDefined()
-        if (!loseGoldOutcome || loseGoldOutcome.kind !== 'lose_gold') return
+        assert(loseGoldOutcome !== undefined && loseGoldOutcome.kind === 'lose_gold')
         expect(loseGoldOutcome.value).toBeGreaterThan(0)
       })
 
       it('Leave 選択肢の outcome に nothing が含まれる', () => {
         const event = repository.findById('the_cleric' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         const leaveChoice = event.choices.find((c) => c.text === 'Leave')
-        expect(leaveChoice).toBeDefined()
-        if (!leaveChoice) return
+        assert(leaveChoice !== undefined)
 
         const nothingOutcome = leaveChoice.outcomes.find((o) => o.kind === 'nothing')
         expect(nothingOutcome).toBeDefined()
@@ -146,12 +138,10 @@ describe('JsonEventRepository', () => {
     describe('dead_adventurer のフィールドが正しくマッピングされている', () => {
       it('Search Body 選択肢に gain_gold と add_card が含まれる', () => {
         const event = repository.findById('dead_adventurer' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         const searchChoice = event.choices.find((c) => c.text === 'Search Body')
-        expect(searchChoice).toBeDefined()
-        if (!searchChoice) return
+        assert(searchChoice !== undefined)
 
         expect(searchChoice.outcomes.some((o) => o.kind === 'gain_gold')).toBe(true)
         expect(searchChoice.outcomes.some((o) => o.kind === 'add_card')).toBe(true)
@@ -159,14 +149,13 @@ describe('JsonEventRepository', () => {
 
       it('add_card の outcome に cardId が含まれる', () => {
         const event = repository.findById('dead_adventurer' as EventId)
-        if (!event) return
+        assert(event !== undefined)
 
         const searchChoice = event.choices.find((c) => c.text === 'Search Body')
-        if (!searchChoice) return
+        assert(searchChoice !== undefined)
 
         const addCardOutcome = searchChoice.outcomes.find((o) => o.kind === 'add_card')
-        expect(addCardOutcome).toBeDefined()
-        if (!addCardOutcome || addCardOutcome.kind !== 'add_card') return
+        assert(addCardOutcome !== undefined && addCardOutcome.kind === 'add_card')
         expect(typeof addCardOutcome.cardId).toBe('string')
         expect(addCardOutcome.cardId.length).toBeGreaterThan(0)
       })
@@ -175,30 +164,26 @@ describe('JsonEventRepository', () => {
     describe('golden_wing のフィールドが正しくマッピングされている', () => {
       it('Take Relic 選択肢に gain_relic が含まれる', () => {
         const event = repository.findById('golden_wing' as EventId)
-        expect(event).toBeDefined()
-        if (!event) return
+        assert(event !== undefined)
 
         const takeRelicChoice = event.choices.find((c) => c.text === 'Take Relic')
-        expect(takeRelicChoice).toBeDefined()
-        if (!takeRelicChoice) return
+        assert(takeRelicChoice !== undefined)
 
         const gainRelicOutcome = takeRelicChoice.outcomes.find((o) => o.kind === 'gain_relic')
-        expect(gainRelicOutcome).toBeDefined()
-        if (!gainRelicOutcome || gainRelicOutcome.kind !== 'gain_relic') return
+        assert(gainRelicOutcome !== undefined && gainRelicOutcome.kind === 'gain_relic')
         expect(typeof gainRelicOutcome.relicId).toBe('string')
         expect(gainRelicOutcome.relicId.length).toBeGreaterThan(0)
       })
 
       it('Take Relic 選択肢に lose_hp が含まれる', () => {
         const event = repository.findById('golden_wing' as EventId)
-        if (!event) return
+        assert(event !== undefined)
 
         const takeRelicChoice = event.choices.find((c) => c.text === 'Take Relic')
-        if (!takeRelicChoice) return
+        assert(takeRelicChoice !== undefined)
 
         const loseHpOutcome = takeRelicChoice.outcomes.find((o) => o.kind === 'lose_hp')
-        expect(loseHpOutcome).toBeDefined()
-        if (!loseHpOutcome || loseHpOutcome.kind !== 'lose_hp') return
+        assert(loseHpOutcome !== undefined && loseHpOutcome.kind === 'lose_hp')
         expect(loseHpOutcome.value).toBeGreaterThan(0)
       })
     })


### PR DESCRIPTION
Closes #133

## 変更内容

### ドメイン層
- `src/shared/types/index.ts` — `EventId` brand type 追加
- `src/domain/entities/EventDefinition.ts` — `EventOutcome`（discriminated union）/ `EventChoice` / `EventDefinition` 型定義
- `src/domain/interfaces/IEventRepository.ts` — `IEventRepository` インターフェース追加

### インフラ層
- `src/infrastructure/data/schemas.ts` — `EventOutcomeSchema`（z.discriminatedUnion）/ `EventChoiceSchema` / `EventSchema` 追加
- `src/infrastructure/data/events.json` — 3件のイベントマスターデータ（the_cleric / dead_adventurer / golden_wing）
- `src/infrastructure/repositories/JsonEventRepository.ts` — `JsonEventRepository` 実装
- `src/infrastructure/repositories/JsonRelicRepository.ts` — `z.array().parse()` パターンに統一
- `src/infrastructure/repositories/JsonCardRepository.ts` — `z.array().parse()` パターンに統一
- `src/infrastructure/repositories/JsonCharacterRepository.ts` — `z.array().parse()` パターンに統一

### テスト
- `tests/infrastructure/repositories/JsonEventRepository.test.ts` — 24件（AC1〜AC3 / No.01/08/22/24/26/27 カバー）

## 受け入れ条件確認

| # | 条件 | 状態 |
|---|------|------|
| AC1 | イベントリポジトリからイベントデータを取得できること | ✅ |
| AC2 | イベントデータに選択肢と結果（HP増減・カード追加等）が含まれること | ✅ |
| AC3 | 不正なイベントデータでもシステムがクラッシュしないこと | ✅（EventSchema.safeParse 検証） |

## 主な設計判断

- **`EventOutcome` を discriminated union に設計** — kindごとに必須フィールドを型レベルで保証し、`value` の undefined 混入リスクを排除。`z.discriminatedUnion` により Zod スキーマが単一の真実源となり、型との二重管理を廃止
- **`z.array(Schema).parse(data)` パターンで全リポジトリ統一** — `as unknown[]` cast と要素ごとの個別 parse を廃止。Relic / Card / Character / Event の4リポジトリすべてで一貫したパターンに
- **テストの `assert` パターン** — `if (!x) return` による silent skip を廃止。`assert(x !== undefined && x.kind === 'y')` で即 fail + TypeScript 型絞り込みを同時に実現

## Test plan
- [ ] `npm run typecheck` 通過
- [ ] `npm run lint` 通過
- [ ] `npm run test:run` 全347件 + 新規24件 通過