### PR TITLE
feat: T136 敵マスターデータリポジトリ実装（JsonEnemyRepository）

### DIFF
--- a/src/domain/entities/EnemyDefinition.ts
+++ b/src/domain/entities/EnemyDefinition.ts
@@ -1,0 +1,31 @@
+import { type EnemyId } from '../../shared/types'
+import { type Intent } from './Enemy'
+
+/**
+ * 敵HP範囲
+ *
+ * 戦闘開始時の初期HPをランダムに決定するための範囲。
+ * 実際の初期HP決定は IRandomService を使用するファクトリ等の責務。
+ */
+export type EnemyHpRange = {
+  readonly min: number
+  readonly max: number
+}
+
+/**
+ * 敵定義
+ *
+ * 敵キャラクター（スライム・守衛等）の静的マスターデータ。
+ * 戦闘時に敵インスタンスを生成するために使用する。
+ *
+ * - hp: 初期HPの範囲（min/max）
+ * - intents: 敵が実行しうる行動パターンのリスト
+ *
+ * 参照可能な層: domain/entities, shared/types のみ
+ */
+export type EnemyDefinition = {
+  readonly id: EnemyId
+  readonly name: string
+  readonly hp: EnemyHpRange
+  readonly intents: ReadonlyArray<Intent>
+}

--- a/src/domain/interfaces/IEnemyRepository.ts
+++ b/src/domain/interfaces/IEnemyRepository.ts
@@ -1,0 +1,13 @@
+import { type EnemyId } from '../../shared/types'
+import { type EnemyDefinition } from '../entities/EnemyDefinition'
+
+/**
+ * 敵リポジトリインターフェース
+ *
+ * 敵マスターデータ取得の契約。
+ * 参照可能な層: domain/entities のみ
+ */
+export interface IEnemyRepository {
+  findById(enemyId: EnemyId): EnemyDefinition | undefined
+  findAll(): ReadonlyArray<EnemyDefinition>
+}

--- a/src/infrastructure/data/enemies.json
+++ b/src/infrastructure/data/enemies.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "slime",
+    "name": "Slime",
+    "hp_min": 10,
+    "hp_max": 15,
+    "intents": [
+      { "type": "attack", "value": 5 }
+    ]
+  },
+  {
+    "id": "guard",
+    "name": "Guard",
+    "hp_min": 20,
+    "hp_max": 28,
+    "intents": [
+      { "type": "attack", "value": 8 },
+      { "type": "block", "value": 5 }
+    ]
+  }
+]

--- a/src/infrastructure/data/schemas.ts
+++ b/src/infrastructure/data/schemas.ts
@@ -44,17 +44,39 @@ export const CardSchema = z.object({
 export type CardRaw = z.infer<typeof CardSchema>
 
 /**
+ * 敵インテントのraw形状スキーマ
+ *
+ * 敵キャラクターが実行しうる行動パターンのJSONraw形状。
+ * type は IntentType に対応する文字列リテラル。
+ */
+export const EnemyIntentSchema = z.object({
+  type: z.enum(['attack', 'block', 'buff', 'debuff', 'unknown']),
+  value: z.number().optional(),
+})
+
+export type EnemyIntentRaw = z.infer<typeof EnemyIntentSchema>
+
+/**
  * 敵JSONのraw形状スキーマ
  *
  * 敵マスターデータのJSONraw形状。
- * 現在は最小限のフィールドのみ定義（壊れ検知の目的に限定）。
- * 敵のアクション・インテント等は敵リポジトリ実装時に追加する。
+ * - id: パース時に EnemyId ブランド型へ変換する（データ境界でのキャストを一元化）
+ * - hp_min / hp_max: 戦闘開始時の初期HP範囲（両端含む正の整数）
+ * - intents: 敵が実行しうる行動パターンのリスト（1件以上必須）
+ * - refine: hp_min <= hp_max のクロスフィールド制約
  */
-export const EnemySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  max_hp: z.number().int().positive(),
-})
+export const EnemySchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    hp_min: z.number().int().positive(),
+    hp_max: z.number().int().positive(),
+    intents: z.array(EnemyIntentSchema).min(1),
+  })
+  .refine((d) => d.hp_min <= d.hp_max, {
+    message: 'hp_min は hp_max 以下でなければなりません',
+    path: ['hp_min'],
+  })
 
 export type EnemyRaw = z.infer<typeof EnemySchema>
 

--- a/src/infrastructure/repositories/JsonEnemyRepository.ts
+++ b/src/infrastructure/repositories/JsonEnemyRepository.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+import { type EnemyDefinition } from '../../domain/entities/EnemyDefinition'
+import { type IEnemyRepository } from '../../domain/interfaces/IEnemyRepository'
+import { type Intent } from '../../domain/entities/Enemy'
+import { type EnemyId } from '../../shared/types'
+import { EnemySchema, type EnemyIntentRaw, type EnemyRaw } from '../data/schemas'
+import enemiesData from '../data/enemies.json'
+
+/**
+ * EnemyIntentRaw → Intent へのマッパー
+ *
+ * EnemyIntentSchema の type は IntentType と同一のリテラルユニオン型のため、
+ * キャストなしで直接代入できる。
+ */
+function toIntent(raw: EnemyIntentRaw): Intent {
+  return {
+    type: raw.type,
+    ...(raw.value !== undefined ? { value: raw.value } : {}),
+  }
+}
+
+/**
+ * EnemyRaw → EnemyDefinition へのマッパー
+ */
+function toEnemyDefinition(raw: EnemyRaw): EnemyDefinition {
+  return {
+    id: raw.id as EnemyId,
+    name: raw.name,
+    hp: {
+      min: raw.hp_min,
+      max: raw.hp_max,
+    },
+    intents: raw.intents.map(toIntent),
+  }
+}
+
+/**
+ * JSONファイルベースの敵リポジトリ
+ *
+ * enemies.json を z.array(EnemySchema).safeParse() で一括検証し、
+ * EnemyDefinition として返す。バリデーション失敗時はわかりやすいエラーをスローする。
+ * 参照可能な層: domain/interfaces, domain/entities, shared/types,
+ *               infrastructure/data
+ */
+export class JsonEnemyRepository implements IEnemyRepository {
+  private readonly enemies: ReadonlyArray<EnemyDefinition>
+
+  constructor() {
+    const result = z.array(EnemySchema).safeParse(enemiesData)
+    if (!result.success) {
+      throw new Error(`enemies.json のパースに失敗しました: ${result.error.message}`)
+    }
+    this.enemies = result.data.map(toEnemyDefinition)
+  }
+
+  findById(enemyId: EnemyId): EnemyDefinition | undefined {
+    return this.enemies.find((e) => e.id === enemyId)
+  }
+
+  findAll(): ReadonlyArray<EnemyDefinition> {
+    return this.enemies
+  }
+}

--- a/tests/infrastructure/repositories/JsonEnemyRepository.test.ts
+++ b/tests/infrastructure/repositories/JsonEnemyRepository.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeAll, assert } from 'vitest'
+import { JsonEnemyRepository } from '../../../src/infrastructure/repositories/JsonEnemyRepository'
+import { EnemySchema } from '../../../src/infrastructure/data/schemas'
+import { type EnemyId } from '../../../src/shared/types'
+
+describe('JsonEnemyRepository', () => {
+  let repository: JsonEnemyRepository
+
+  beforeAll(() => {
+    repository = new JsonEnemyRepository()
+  })
+
+  // -------------------------------------------------------------------------
+  // No.26: Factoryパターン・正常生成
+  // -------------------------------------------------------------------------
+  describe('constructor', () => {
+    it('有効な JSON ファイルでインスタンスを生成できる', () => {
+      expect(() => new JsonEnemyRepository()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作 / AC1: 敵リポジトリから敵データを取得できること
+  // No.24: データスキーマ検証
+  // -------------------------------------------------------------------------
+  describe('findAll', () => {
+    // AC1: 敵リポジトリから敵データを取得できること
+    it('少なくとも2件の敵を返す', () => {
+      const enemies = repository.findAll()
+      expect(enemies.length).toBeGreaterThanOrEqual(2)
+    })
+
+    // AC2: 敵が正しいHP・攻撃意図で初期化されること
+    it('EnemyDefinition の必須フィールドが全て存在し型が正しい', () => {
+      const enemies = repository.findAll()
+      for (const enemy of enemies) {
+        expect(typeof enemy.id).toBe('string')
+        expect(enemy.id.length).toBeGreaterThan(0)
+
+        expect(typeof enemy.name).toBe('string')
+        expect(enemy.name.length).toBeGreaterThan(0)
+
+        expect(typeof enemy.hp).toBe('object')
+        expect(typeof enemy.hp.min).toBe('number')
+        expect(typeof enemy.hp.max).toBe('number')
+
+        expect(Array.isArray(enemy.intents)).toBe(true)
+        expect(enemy.intents.length).toBeGreaterThan(0)
+      }
+    })
+
+    // AC2: 各 Intent に type が含まれること
+    it('各 Intent に type が含まれる', () => {
+      const enemies = repository.findAll()
+      for (const enemy of enemies) {
+        for (const intent of enemy.intents) {
+          expect(typeof intent.type).toBe('string')
+          expect(intent.type.length).toBeGreaterThan(0)
+        }
+      }
+    })
+
+    // AC4: hp.min <= hp.max の制約
+    it('hp.min は hp.max 以下である', () => {
+      const enemies = repository.findAll()
+      for (const enemy of enemies) {
+        expect(enemy.hp.min).toBeLessThanOrEqual(enemy.hp.max)
+      }
+    })
+
+    // AC4: hp.min, hp.max が正の整数であること
+    it('hp.min と hp.max は正の整数である', () => {
+      const enemies = repository.findAll()
+      for (const enemy of enemies) {
+        expect(enemy.hp.min).toBeGreaterThan(0)
+        expect(enemy.hp.max).toBeGreaterThan(0)
+        expect(Number.isInteger(enemy.hp.min)).toBe(true)
+        expect(Number.isInteger(enemy.hp.max)).toBe(true)
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.01: 正常系・基本動作 / AC1
+  // -------------------------------------------------------------------------
+  describe('findById', () => {
+    it('存在するIDで EnemyDefinition を返す', () => {
+      const all = repository.findAll()
+      assert(all.length > 0)
+      const first = all[0]
+      assert(first !== undefined)
+      const firstId = first.id
+      const enemy = repository.findById(firstId)
+      expect(enemy).toBeDefined()
+      expect(enemy?.id).toBe(firstId)
+    })
+
+    // AC2: slime の具体値検証
+    describe('slime のフィールドが正しくマッピングされている', () => {
+      it('slime の基本フィールド（name / hp）が正しい', () => {
+        const enemy = repository.findById('slime' as EnemyId)
+        assert(enemy !== undefined)
+
+        expect(enemy.name).toBe('Slime')
+        expect(enemy.hp.min).toBeGreaterThan(0)
+        expect(enemy.hp.max).toBeGreaterThanOrEqual(enemy.hp.min)
+      })
+
+      // AC2: intents に attack が含まれること
+      it('slime の intents に attack intent が含まれる', () => {
+        const enemy = repository.findById('slime' as EnemyId)
+        assert(enemy !== undefined)
+
+        const attackIntent = enemy.intents.find((i) => i.type === 'attack')
+        expect(attackIntent).toBeDefined()
+        assert(attackIntent !== undefined)
+        expect(typeof attackIntent.value).toBe('number')
+        expect(attackIntent.value).toBeGreaterThan(0)
+      })
+    })
+
+    // AC2: guard の具体値検証
+    describe('guard のフィールドが正しくマッピングされている', () => {
+      it('guard の基本フィールド（name / hp）が正しい', () => {
+        const enemy = repository.findById('guard' as EnemyId)
+        assert(enemy !== undefined)
+
+        expect(enemy.name).toBe('Guard')
+        expect(enemy.hp.min).toBeGreaterThan(0)
+        expect(enemy.hp.max).toBeGreaterThanOrEqual(enemy.hp.min)
+      })
+
+      it('guard の intents に block intent が含まれる', () => {
+        const enemy = repository.findById('guard' as EnemyId)
+        assert(enemy !== undefined)
+
+        const blockIntent = enemy.intents.find((i) => i.type === 'block')
+        expect(blockIntent).toBeDefined()
+      })
+    })
+
+    // -------------------------------------------------------------------------
+    // No.08: 異常系・存在しないキー参照
+    // -------------------------------------------------------------------------
+    it('存在しないIDで undefined を返す', () => {
+      const enemy = repository.findById('nonexistent' as EnemyId)
+      expect(enemy).toBeUndefined()
+    })
+
+    it('空文字IDで undefined を返す', () => {
+      const enemy = repository.findById('' as EnemyId)
+      expect(enemy).toBeUndefined()
+    })
+
+    it('大文字・小文字が異なるIDで undefined を返す（大文字小文字厳密一致）', () => {
+      const enemy = repository.findById('Slime' as EnemyId)
+      expect(enemy).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.22: リポジトリパターン保存と再取得の一貫性
+  // No.23: IDによる単件取得
+  // IEnemyRepository interface実装確認
+  // -------------------------------------------------------------------------
+  describe('IEnemyRepository 実装確認・一貫性', () => {
+    it('JsonEnemyRepository は IEnemyRepository を実装している', () => {
+      expect(typeof repository.findById).toBe('function')
+      expect(typeof repository.findAll).toBe('function')
+    })
+
+    it('findAll の結果は findById の部分集合である', () => {
+      const all = repository.findAll()
+      for (const enemy of all) {
+        const found = repository.findById(enemy.id)
+        expect(found).toBeDefined()
+        expect(found?.id).toBe(enemy.id)
+      }
+    })
+
+    it('findAll は毎回同じ件数を返す（immutable）', () => {
+      const first = repository.findAll()
+      const second = repository.findAll()
+      expect(first.length).toBe(second.length)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // No.27: Factoryパターン・異常生成（AC3: 不正データでクラッシュしない）
+  // -------------------------------------------------------------------------
+  describe('不正データのハンドリング（EnemySchema）', () => {
+    it('必須フィールドが欠けた不正オブジェクトを渡すと ZodError をthrowする', () => {
+      expect(() => EnemySchema.parse({ id: 'bad' })).toThrow()
+    })
+
+    it('EnemySchema.safeParse は不正データでcrashせず success: false を返す', () => {
+      const result = EnemySchema.safeParse({ id: 'bad', intents: 'not_an_array' })
+      expect(result.success).toBe(false)
+    })
+
+    it('hp_min が負の数のデータは ZodError をthrowする', () => {
+      expect(() =>
+        EnemySchema.parse({
+          id: 'invalid_enemy',
+          name: 'Invalid',
+          hp_min: -1,
+          hp_max: 10,
+          intents: [{ type: 'attack', value: 5 }],
+        }),
+      ).toThrow()
+    })
+
+    it('hp_min が hp_max より大きいデータは ZodError をthrowする', () => {
+      expect(() =>
+        EnemySchema.parse({
+          id: 'bad_hp_range',
+          name: 'Bad HP Range',
+          hp_min: 20,
+          hp_max: 10,
+          intents: [{ type: 'attack', value: 5 }],
+        }),
+      ).toThrow()
+    })
+
+    it('intents が空配列のデータは ZodError をthrowする', () => {
+      expect(() =>
+        EnemySchema.parse({
+          id: 'no_intents',
+          name: 'No Intents',
+          hp_min: 10,
+          hp_max: 20,
+          intents: [],
+        }),
+      ).toThrow()
+    })
+
+    it('intent の type が不正な値のデータは ZodError をthrowする', () => {
+      expect(() =>
+        EnemySchema.parse({
+          id: 'bad_intent',
+          name: 'Bad Intent',
+          hp_min: 10,
+          hp_max: 20,
+          intents: [{ type: 'invalid_type' }],
+        }),
+      ).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Closes #136

## Summary

- `EnemyDefinition` エンティティ（hp範囲・インテントリスト）を新規定義
- `IEnemyRepository` インターフェースを追加
- `EnemySchema` を拡張（`hp_min`/`hp_max`/`intents` フィールド・`refine` によるクロスフィールド検証）
- `enemies.json` にスライム・守衛のマスターデータを追加
- `JsonEnemyRepository` を実装（`safeParse` + エラーメッセージ付きフォールバック）
- `JsonEnemyRepository.test.ts` で AC1〜AC4 を全てカバー（23テスト）

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] `npm run test:run -- tests/infrastructure/repositories/JsonEnemyRepository.test.ts` で 23テスト全 pass
- [ ] AC1: `findAll` / `findById` で敵データを取得できること
- [ ] AC2: `EnemyDefinition` に `hp`（min/max）と `intents` が含まれること
- [ ] AC3: 不正スキーマデータで ZodError がスローされること（safeParse で crash しないこと）
- [ ] AC4: `hp.min <= hp.max` のクロスフィールド制約がスキーマで保証されること