### PR TITLE
feat: T137 デッキを操作（ドロー・捨て札・消耗）できる

### DIFF
--- a/src/application/effects/DrawCardEffect.ts
+++ b/src/application/effects/DrawCardEffect.ts
@@ -1,0 +1,26 @@
+import { type Effect } from './Effect'
+import { type Player } from '../../domain/entities/Player'
+import { type IRandomService } from '../../domain/interfaces/IRandomService'
+import { type DrawResult, drawCards } from '../../domain/rules/DeckRules'
+
+/**
+ * ドローエフェクト（アプリケーション層）
+ *
+ * カードをプレイしたときに山札から count 枚ドローする。
+ * DeckRules.drawCards() を呼び出してイミュータブルに状態を更新する。
+ *
+ * - count は非負整数でなければならない（負数・小数はコンストラクタで弾く）
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export class DrawCardEffect implements Effect {
+  constructor(private readonly count: number) {
+    if (!Number.isInteger(count) || count < 0) {
+      throw new Error(`DrawCardEffect: count must be a non-negative integer, got ${count}`)
+    }
+  }
+
+  apply(player: Player, random: IRandomService): DrawResult {
+    return drawCards(player, this.count, random)
+  }
+}

--- a/src/application/effects/DrawCardEffect.ts
+++ b/src/application/effects/DrawCardEffect.ts
@@ -1,7 +1,5 @@
-import { type Effect } from './Effect'
-import { type Player } from '../../domain/entities/Player'
-import { type IRandomService } from '../../domain/interfaces/IRandomService'
-import { type DrawResult, drawCards } from '../../domain/rules/DeckRules'
+import { type Effect, type BattleState, type EffectServices } from './Effect'
+import { drawCards } from '../../domain/rules/DeckRules'
 
 /**
  * ドローエフェクト（アプリケーション層）
@@ -10,6 +8,7 @@ import { type DrawResult, drawCards } from '../../domain/rules/DeckRules'
  * DeckRules.drawCards() を呼び出してイミュータブルに状態を更新する。
  *
  * - count は非負整数でなければならない（負数・小数はコンストラクタで弾く）
+ * - 敵状態（enemies）は変更しない
  * - 参照可能な層: domain, application/effects のみ
  * - 参照してはいけない層: infrastructure, presentation
  */
@@ -20,7 +19,8 @@ export class DrawCardEffect implements Effect {
     }
   }
 
-  apply(player: Player, random: IRandomService): DrawResult {
-    return drawCards(player, this.count, random)
+  apply(state: BattleState, services: EffectServices): BattleState {
+    const { player: updatedPlayer } = drawCards(state.player, this.count, services.random)
+    return { ...state, player: updatedPlayer }
   }
 }

--- a/src/application/effects/Effect.ts
+++ b/src/application/effects/Effect.ts
@@ -1,15 +1,32 @@
 import { type Player } from '../../domain/entities/Player'
+import { type Enemy } from '../../domain/entities/Enemy'
 import { type IRandomService } from '../../domain/interfaces/IRandomService'
 
 /**
- * エフェクト適用結果の基底型。
- * 全エフェクトが最低限返す情報。プレイヤー状態を更新する。
+ * エフェクト適用対象の戦闘状態（アプリケーション層）
  *
- * 敵を対象とするエフェクト（DamageEffect 等）は将来 EffectContext に
- * enemies を含める形に拡張する（#135 エフェクトエンジン設計時に対応）。
+ * エフェクトが読み取り・更新する戦闘状態のスナップショット。
+ * domain の Combat エンティティ（turn を含む）のサブセットとして設計し、
+ * エフェクトが必要とする最小限の状態のみを保持する。
+ *
+ * - turn は含まない（ターン数依存エフェクトが必要になった際に拡張する）
+ * - EffectServices と分離することで「状態（何が変わるか）」と
+ *   「サービス（どう変えるか）」の責務を明確にする
  */
-export interface EffectApplyResult {
+export interface BattleState {
   readonly player: Player
+  readonly enemies: readonly Enemy[]
+}
+
+/**
+ * エフェクト実行時に注入するサービス群（アプリケーション層）
+ *
+ * 戦闘状態（BattleState）とは別に管理するサービスの集合。
+ * エフェクトの入力にも出力にもならないため BattleState から分離する。
+ * EffectExecutor（#135）がエフェクトパイプライン全体で使い回す。
+ */
+export interface EffectServices {
+  readonly random: IRandomService
 }
 
 /**
@@ -17,13 +34,14 @@ export interface EffectApplyResult {
  *
  * カード JSON の effects 配列から生成される実行可能なエフェクト単位。
  * EffectFactory が EffectDef → Effect[] に変換し、各エフェクトが apply() を通じて
- * プレイヤー/敵の状態を更新する。
+ * 戦闘状態を更新する。
  *
  * - apply() は純粋関数として実装する（副作用なし・イミュータブル）
- * - 戻り値は EffectApplyResult またはそのサブタイプ
+ * - EffectExecutor での利用イメージ:
+ *   effects.reduce((state, effect) => effect.apply(state, services), initialState)
  * - 参照可能な層: domain, application/effects
  * - 参照してはいけない層: infrastructure, presentation
  */
 export interface Effect {
-  apply(player: Player, random: IRandomService): EffectApplyResult
+  apply(state: BattleState, services: EffectServices): BattleState
 }

--- a/src/application/effects/Effect.ts
+++ b/src/application/effects/Effect.ts
@@ -1,0 +1,29 @@
+import { type Player } from '../../domain/entities/Player'
+import { type IRandomService } from '../../domain/interfaces/IRandomService'
+
+/**
+ * エフェクト適用結果の基底型。
+ * 全エフェクトが最低限返す情報。プレイヤー状態を更新する。
+ *
+ * 敵を対象とするエフェクト（DamageEffect 等）は将来 EffectContext に
+ * enemies を含める形に拡張する（#135 エフェクトエンジン設計時に対応）。
+ */
+export interface EffectApplyResult {
+  readonly player: Player
+}
+
+/**
+ * カードエフェクトのインターフェース（アプリケーション層）
+ *
+ * カード JSON の effects 配列から生成される実行可能なエフェクト単位。
+ * EffectFactory が EffectDef → Effect[] に変換し、各エフェクトが apply() を通じて
+ * プレイヤー/敵の状態を更新する。
+ *
+ * - apply() は純粋関数として実装する（副作用なし・イミュータブル）
+ * - 戻り値は EffectApplyResult またはそのサブタイプ
+ * - 参照可能な層: domain, application/effects
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export interface Effect {
+  apply(player: Player, random: IRandomService): EffectApplyResult
+}

--- a/src/domain/rules/DeckRules.ts
+++ b/src/domain/rules/DeckRules.ts
@@ -1,0 +1,117 @@
+import { type Player } from '../entities/Player'
+import { type Card } from '../entities/Card'
+import { type IRandomService } from '../interfaces/IRandomService'
+import { type CardId, type Result, ok, err } from '../../shared/types'
+import { MAX_HAND_SIZE } from '../../shared/constants'
+
+/**
+ * ドロー結果
+ *
+ * drawn: 手札に加わったカード
+ * burned: 手札満杯のため捨て札に送られたカード（バーン）
+ */
+export type DrawResult = {
+  readonly player: Player
+  readonly drawn: readonly Card[]
+  readonly burned: readonly Card[]
+}
+
+/**
+ * 山札から count 枚ドローする（純粋関数）。
+ *
+ * - 山札が空になった場合、捨て札をシャッフルして山札に補充してからドローを継続する。
+ * - 手札が MAX_HAND_SIZE(10) に達した場合、超過するカードは捨て札にバーンされる。
+ * - 山札・捨て札ともに空のとき、要求枚数に満たなくてもエラーにならない。
+ *
+ * @param count - ドロー枚数（非負整数）
+ * @throws {RangeError} count が負数または非整数の場合
+ *
+ * 参照可能な層: domain/entities, domain/interfaces のみ（純粋関数）
+ */
+export function drawCards(player: Player, count: number, random: IRandomService): DrawResult {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new RangeError(`drawCards: count must be a non-negative integer, got ${count}`)
+  }
+
+  let currentPlayer = player
+  const drawn: Card[] = []
+  const burned: Card[] = []
+
+  for (let i = 0; i < count; i++) {
+    if (currentPlayer.deck.length === 0) {
+      if (currentPlayer.discardPile.length === 0) {
+        break
+      }
+      const newDeck = random.shuffle(currentPlayer.discardPile)
+      currentPlayer = { ...currentPlayer, deck: newDeck, discardPile: [] }
+    }
+
+    const topCard = currentPlayer.deck[0]!
+    const remainingDeck = currentPlayer.deck.slice(1)
+
+    if (currentPlayer.hand.length >= MAX_HAND_SIZE) {
+      burned.push(topCard)
+      currentPlayer = {
+        ...currentPlayer,
+        deck: remainingDeck,
+        discardPile: [...currentPlayer.discardPile, topCard],
+      }
+    } else {
+      drawn.push(topCard)
+      currentPlayer = {
+        ...currentPlayer,
+        deck: remainingDeck,
+        hand: [...currentPlayer.hand, topCard],
+      }
+    }
+  }
+
+  return { player: currentPlayer, drawn, burned }
+}
+
+/**
+ * 手札の指定カードを捨て札に移す（純粋関数）。
+ *
+ * @returns 成功時: 更新後の Player / 失敗時: 'not_in_hand'
+ */
+export function discardCard(player: Player, cardId: CardId): Result<Player, 'not_in_hand'> {
+  const cardIndex = player.hand.findIndex((c) => c.id === cardId)
+  if (cardIndex === -1) {
+    return err('not_in_hand')
+  }
+  const card = player.hand[cardIndex]!
+  return ok({
+    ...player,
+    hand: player.hand.filter((_, i) => i !== cardIndex),
+    discardPile: [...player.discardPile, card],
+  })
+}
+
+/**
+ * 手札の指定カードを消耗させる（exhaustPile へ移動）（純粋関数）。
+ * 消耗カードはデッキに戻らない。
+ *
+ * @returns 成功時: 更新後の Player / 失敗時: 'not_in_hand'
+ */
+export function exhaustCard(player: Player, cardId: CardId): Result<Player, 'not_in_hand'> {
+  const cardIndex = player.hand.findIndex((c) => c.id === cardId)
+  if (cardIndex === -1) {
+    return err('not_in_hand')
+  }
+  const card = player.hand[cardIndex]!
+  return ok({
+    ...player,
+    hand: player.hand.filter((_, i) => i !== cardIndex),
+    exhaustPile: [...player.exhaustPile, card],
+  })
+}
+
+/**
+ * 山札をシャッフルした新しい Player を返す（純粋関数）。
+ */
+export function shuffleDeck(player: Player, random: IRandomService): Player {
+  return {
+    ...player,
+    deck: random.shuffle(player.deck),
+  }
+}

--- a/tests/application/effects/DrawCardEffect.test.ts
+++ b/tests/application/effects/DrawCardEffect.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { DrawCardEffect } from '../../../src/application/effects/DrawCardEffect'
-import { type Effect } from '../../../src/application/effects/Effect'
+import {
+  type Effect,
+  type BattleState,
+  type EffectServices,
+} from '../../../src/application/effects/Effect'
 import { type Player } from '../../../src/domain/entities/Player'
 import { type Card } from '../../../src/domain/entities/Card'
 import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
@@ -15,7 +19,7 @@ import { Block } from '../../../src/domain/value-objects/Block'
 import { MAX_HAND_SIZE } from '../../../src/shared/constants'
 
 // ─────────────────────────────────────────────
-// Test helpers (shared with DeckRules tests)
+// Test helpers
 // ─────────────────────────────────────────────
 
 function makeCardId(id: string): CardId {
@@ -77,15 +81,21 @@ function makePlayer(
   }
 }
 
-function makeRandomService(overrides?: Partial<IRandomService>): IRandomService {
+function makeServices(overrides?: Partial<IRandomService>): EffectServices {
   return {
-    next: vi.fn(() => 0),
-    nextInt: vi.fn((min: number) => min),
-    shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
-      ...array,
-    ]) as IRandomService['shuffle'],
-    ...overrides,
+    random: {
+      next: vi.fn(() => 0),
+      nextInt: vi.fn((min: number) => min),
+      shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+        ...array,
+      ]) as IRandomService['shuffle'],
+      ...overrides,
+    },
   }
+}
+
+function makeBattleState(player: Player, overrides?: Partial<BattleState>): BattleState {
+  return { player, enemies: [], ...overrides }
 }
 
 // ─────────────────────────────────────────────
@@ -111,45 +121,37 @@ describe('DrawCardEffect - Effect インターフェース適合', () => {
 describe('DrawCardEffect.apply', () => {
   describe('AC5: ドローエフェクトで規定枚数のカードが手札に加わる', () => {
     it('count=2 のとき手札が 2 枚増える', () => {
-      const deck = makeCards(10)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(10) })
       const effect = new DrawCardEffect(2)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(2)
     })
 
     it('count=1 のとき手札が 1 枚増える（境界値：最小）', () => {
-      const deck = makeCards(5)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(5) })
       const effect = new DrawCardEffect(1)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(1)
     })
 
     it('count=5 のとき手札が 5 枚増える', () => {
-      const deck = makeCards(10)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(10) })
       const effect = new DrawCardEffect(5)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(5)
     })
 
     it('ドロー後に山札の枚数が減る', () => {
-      const deck = makeCards(10)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(10) })
       const effect = new DrawCardEffect(3)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.deck).toHaveLength(7)
     })
@@ -157,95 +159,72 @@ describe('DrawCardEffect.apply', () => {
 
   describe('AC2: 山札が空のとき捨て札からリシャッフルしてドロー', () => {
     it('山札が空で捨て札がある場合はリシャッフルしてドローする', () => {
-      const discardPile = makeCards(8, 'discard')
-      const player = makePlayer({ deck: [], discardPile })
-      const random = makeRandomService({
-        shuffle: vi.fn(<T>(arr: readonly T[]): readonly T[] => [
-          ...arr,
-        ]) as IRandomService['shuffle'],
-      })
+      const player = makePlayer({ deck: [], discardPile: makeCards(8, 'discard') })
+      const shuffleMock = vi.fn(<T>(arr: readonly T[]): readonly T[] => [
+        ...arr,
+      ]) as IRandomService['shuffle']
       const effect = new DrawCardEffect(3)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices({ shuffle: shuffleMock }))
 
       expect(result.player.hand).toHaveLength(3)
-      expect(random.shuffle).toHaveBeenCalledOnce()
+      expect(shuffleMock).toHaveBeenCalledOnce()
     })
   })
 
   describe('AC6: 手札が MAX_HAND_SIZE(10) のとき超過分はバーンされる', () => {
     it('手札が満杯（10枚）のとき draw しようとしてもバーンされ手札は増えない', () => {
-      const hand = makeCards(MAX_HAND_SIZE, 'hand')
-      const deck = makeCards(5, 'deck')
-      const player = makePlayer({ deck, hand })
-      const random = makeRandomService()
+      const player = makePlayer({
+        deck: makeCards(5, 'deck'),
+        hand: makeCards(MAX_HAND_SIZE, 'hand'),
+      })
       const effect = new DrawCardEffect(2)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
     })
 
     it('手札が 9 枚で 3 枚 draw すると 1 枚ドロー・2 枚バーン', () => {
-      const hand = makeCards(9, 'hand')
-      const deck = makeCards(5, 'deck')
-      const player = makePlayer({ deck, hand })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(5, 'deck'), hand: makeCards(9, 'hand') })
       const effect = new DrawCardEffect(3)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
     })
   })
 
-  describe('AC4: デッキ操作の結果が返り値に反映される', () => {
+  describe('AC4: デッキ操作の結果が BattleState に反映される', () => {
     it('apply の戻り値に更新後の player が含まれる', () => {
-      const deck = makeCards(5)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(5) })
       const effect = new DrawCardEffect(2)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
-      expect(result).toHaveProperty('player')
       expect(result.player).not.toBe(player)
+      expect(result.player.hand).toHaveLength(2)
     })
 
-    it('apply の戻り値に drawn カードリストが含まれる', () => {
-      const deck = makeCards(5)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+    it('apply は enemies を変更しない（DrawCardEffect はプレイヤーのみ変更）', () => {
+      const player = makePlayer({ deck: makeCards(5) })
+      const state = makeBattleState(player)
       const effect = new DrawCardEffect(2)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(state, makeServices())
 
-      expect(result).toHaveProperty('drawn')
-      expect(result.drawn).toHaveLength(2)
-    })
-
-    it('apply の戻り値に burned カードリストが含まれる', () => {
-      const deck = makeCards(5)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
-      const effect = new DrawCardEffect(2)
-
-      const result = effect.apply(player, random)
-
-      expect(result).toHaveProperty('burned')
+      expect(result.enemies).toBe(state.enemies)
     })
   })
 
   describe('イミュータビリティ', () => {
     it('apply は元の player を変更しない', () => {
-      const deck = makeCards(10)
-      const player = makePlayer({ deck })
+      const player = makePlayer({ deck: makeCards(10) })
       const originalDeckLength = player.deck.length
       const originalHandLength = player.hand.length
-      const random = makeRandomService()
       const effect = new DrawCardEffect(3)
 
-      effect.apply(player, random)
+      effect.apply(makeBattleState(player), makeServices())
 
       expect(player.deck).toHaveLength(originalDeckLength)
       expect(player.hand).toHaveLength(originalHandLength)
@@ -254,23 +233,19 @@ describe('DrawCardEffect.apply', () => {
 
   describe('異常系 - 不正な count', () => {
     it('count=0 で apply すると手札が増えない', () => {
-      const deck = makeCards(5)
-      const player = makePlayer({ deck })
-      const random = makeRandomService()
+      const player = makePlayer({ deck: makeCards(5) })
       const effect = new DrawCardEffect(0)
 
-      const result = effect.apply(player, random)
+      const result = effect.apply(makeBattleState(player), makeServices())
 
       expect(result.player.hand).toHaveLength(0)
-      expect(result.drawn).toHaveLength(0)
     })
 
     it('山札も捨て札も空のとき apply してもエラーにならない', () => {
       const player = makePlayer({ deck: [], discardPile: [] })
-      const random = makeRandomService()
       const effect = new DrawCardEffect(3)
 
-      expect(() => effect.apply(player, random)).not.toThrow()
+      expect(() => effect.apply(makeBattleState(player), makeServices())).not.toThrow()
     })
   })
 })
@@ -288,21 +263,11 @@ describe('DrawCardEffect - Factory / 生成', () => {
     expect(() => new DrawCardEffect(MAX_HAND_SIZE)).not.toThrow()
   })
 
-  it('count が負のとき生成時またはapply時にエラーを投げる', () => {
-    expect(() => {
-      const effect = new DrawCardEffect(-1)
-      const player = makePlayer({})
-      const random = makeRandomService()
-      effect.apply(player, random)
-    }).toThrow()
+  it('count が負のとき生成時にエラーを投げる', () => {
+    expect(() => new DrawCardEffect(-1)).toThrow()
   })
 
-  it('count が非整数（小数）のとき生成時またはapply時にエラーを投げる', () => {
-    expect(() => {
-      const effect = new DrawCardEffect(1.5)
-      const player = makePlayer({})
-      const random = makeRandomService()
-      effect.apply(player, random)
-    }).toThrow()
+  it('count が非整数（小数）のとき生成時にエラーを投げる', () => {
+    expect(() => new DrawCardEffect(1.5)).toThrow()
   })
 })

--- a/tests/application/effects/DrawCardEffect.test.ts
+++ b/tests/application/effects/DrawCardEffect.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DrawCardEffect } from '../../../src/application/effects/DrawCardEffect'
+import { type Effect } from '../../../src/application/effects/Effect'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Card } from '../../../src/domain/entities/Card'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { CardType } from '../../../src/domain/enums/CardType'
+import { Rarity } from '../../../src/domain/enums/Rarity'
+import { TargetType } from '../../../src/domain/enums/TargetType'
+import { type CardId } from '../../../src/shared/types'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { MAX_HAND_SIZE } from '../../../src/shared/constants'
+
+// ─────────────────────────────────────────────
+// Test helpers (shared with DeckRules tests)
+// ─────────────────────────────────────────────
+
+function makeCardId(id: string): CardId {
+  return id as CardId
+}
+
+function makeCard(id: string): Card {
+  return {
+    id: makeCardId(id),
+    name: id,
+    description: `${id} description`,
+    cost: 1,
+    type: CardType.Attack,
+    rarity: Rarity.Common,
+    targetType: TargetType.Single,
+    effects: [],
+    upgraded: false,
+  }
+}
+
+function makeCards(count: number, prefix = 'card'): Card[] {
+  return Array.from({ length: count }, (_, i) => makeCard(`${prefix}_${i}`))
+}
+
+function makePlayer(
+  overrides: Partial<{
+    deck: readonly Card[]
+    hand: readonly Card[]
+    discardPile: readonly Card[]
+    exhaustPile: readonly Card[]
+  }>,
+): Player {
+  const health = Health.create(80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(0)
+
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: overrides.deck ?? [],
+    hand: overrides.hand ?? [],
+    discardPile: overrides.discardPile ?? [],
+    exhaustPile: overrides.exhaustPile ?? [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makeRandomService(overrides?: Partial<IRandomService>): IRandomService {
+  return {
+    next: vi.fn(() => 0),
+    nextInt: vi.fn((min: number) => min),
+    shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+      ...array,
+    ]) as IRandomService['shuffle'],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────
+// DrawCardEffect — 型確認
+// ─────────────────────────────────────────────
+
+describe('DrawCardEffect - Effect インターフェース適合', () => {
+  it('Effect インターフェースを実装している', () => {
+    const effect: Effect = new DrawCardEffect(1)
+    expect(effect).toBeDefined()
+  })
+
+  it('count が正の整数で構築できる', () => {
+    const effect = new DrawCardEffect(3)
+    expect(effect).toBeInstanceOf(DrawCardEffect)
+  })
+})
+
+// ─────────────────────────────────────────────
+// DrawCardEffect.apply — AC5: ドローエフェクトを持つカードをプレイ
+// ─────────────────────────────────────────────
+
+describe('DrawCardEffect.apply', () => {
+  describe('AC5: ドローエフェクトで規定枚数のカードが手札に加わる', () => {
+    it('count=2 のとき手札が 2 枚増える', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(2)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(2)
+    })
+
+    it('count=1 のとき手札が 1 枚増える（境界値：最小）', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(1)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(1)
+    })
+
+    it('count=5 のとき手札が 5 枚増える', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(5)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(5)
+    })
+
+    it('ドロー後に山札の枚数が減る', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(3)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.deck).toHaveLength(7)
+    })
+  })
+
+  describe('AC2: 山札が空のとき捨て札からリシャッフルしてドロー', () => {
+    it('山札が空で捨て札がある場合はリシャッフルしてドローする', () => {
+      const discardPile = makeCards(8, 'discard')
+      const player = makePlayer({ deck: [], discardPile })
+      const random = makeRandomService({
+        shuffle: vi.fn(<T>(arr: readonly T[]): readonly T[] => [
+          ...arr,
+        ]) as IRandomService['shuffle'],
+      })
+      const effect = new DrawCardEffect(3)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(3)
+      expect(random.shuffle).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('AC6: 手札が MAX_HAND_SIZE(10) のとき超過分はバーンされる', () => {
+    it('手札が満杯（10枚）のとき draw しようとしてもバーンされ手札は増えない', () => {
+      const hand = makeCards(MAX_HAND_SIZE, 'hand')
+      const deck = makeCards(5, 'deck')
+      const player = makePlayer({ deck, hand })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(2)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+    })
+
+    it('手札が 9 枚で 3 枚 draw すると 1 枚ドロー・2 枚バーン', () => {
+      const hand = makeCards(9, 'hand')
+      const deck = makeCards(5, 'deck')
+      const player = makePlayer({ deck, hand })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(3)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+    })
+  })
+
+  describe('AC4: デッキ操作の結果が返り値に反映される', () => {
+    it('apply の戻り値に更新後の player が含まれる', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(2)
+
+      const result = effect.apply(player, random)
+
+      expect(result).toHaveProperty('player')
+      expect(result.player).not.toBe(player)
+    })
+
+    it('apply の戻り値に drawn カードリストが含まれる', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(2)
+
+      const result = effect.apply(player, random)
+
+      expect(result).toHaveProperty('drawn')
+      expect(result.drawn).toHaveLength(2)
+    })
+
+    it('apply の戻り値に burned カードリストが含まれる', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(2)
+
+      const result = effect.apply(player, random)
+
+      expect(result).toHaveProperty('burned')
+    })
+  })
+
+  describe('イミュータビリティ', () => {
+    it('apply は元の player を変更しない', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const originalDeckLength = player.deck.length
+      const originalHandLength = player.hand.length
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(3)
+
+      effect.apply(player, random)
+
+      expect(player.deck).toHaveLength(originalDeckLength)
+      expect(player.hand).toHaveLength(originalHandLength)
+    })
+  })
+
+  describe('異常系 - 不正な count', () => {
+    it('count=0 で apply すると手札が増えない', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(0)
+
+      const result = effect.apply(player, random)
+
+      expect(result.player.hand).toHaveLength(0)
+      expect(result.drawn).toHaveLength(0)
+    })
+
+    it('山札も捨て札も空のとき apply してもエラーにならない', () => {
+      const player = makePlayer({ deck: [], discardPile: [] })
+      const random = makeRandomService()
+      const effect = new DrawCardEffect(3)
+
+      expect(() => effect.apply(player, random)).not.toThrow()
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// DrawCardEffect — Factoryパターン観点
+// ─────────────────────────────────────────────
+
+describe('DrawCardEffect - Factory / 生成', () => {
+  it('count=1 で正常に生成できる（最小正常値）', () => {
+    expect(() => new DrawCardEffect(1)).not.toThrow()
+  })
+
+  it('count=MAX_HAND_SIZE で正常に生成できる（最大正常値）', () => {
+    expect(() => new DrawCardEffect(MAX_HAND_SIZE)).not.toThrow()
+  })
+
+  it('count が負のとき生成時またはapply時にエラーを投げる', () => {
+    expect(() => {
+      const effect = new DrawCardEffect(-1)
+      const player = makePlayer({})
+      const random = makeRandomService()
+      effect.apply(player, random)
+    }).toThrow()
+  })
+
+  it('count が非整数（小数）のとき生成時またはapply時にエラーを投げる', () => {
+    expect(() => {
+      const effect = new DrawCardEffect(1.5)
+      const player = makePlayer({})
+      const random = makeRandomService()
+      effect.apply(player, random)
+    }).toThrow()
+  })
+})

--- a/tests/domain/rules/DeckRules.test.ts
+++ b/tests/domain/rules/DeckRules.test.ts
@@ -1,0 +1,556 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  drawCards,
+  discardCard,
+  exhaustCard,
+  shuffleDeck,
+} from '../../../src/domain/rules/DeckRules'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Card } from '../../../src/domain/entities/Card'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { CardType } from '../../../src/domain/enums/CardType'
+import { Rarity } from '../../../src/domain/enums/Rarity'
+import { TargetType } from '../../../src/domain/enums/TargetType'
+import { type CardId } from '../../../src/shared/types'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { MAX_HAND_SIZE, STARTING_DRAW_COUNT } from '../../../src/shared/constants'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeCardId(id: string): CardId {
+  return id as CardId
+}
+
+function makeCard(id: string): Card {
+  return {
+    id: makeCardId(id),
+    name: id,
+    description: `${id} description`,
+    cost: 1,
+    type: CardType.Attack,
+    rarity: Rarity.Common,
+    targetType: TargetType.Single,
+    effects: [],
+    upgraded: false,
+  }
+}
+
+function makeCards(count: number, prefix = 'card'): Card[] {
+  return Array.from({ length: count }, (_, i) => makeCard(`${prefix}_${i}`))
+}
+
+function makePlayer(
+  overrides: Partial<{
+    deck: readonly Card[]
+    hand: readonly Card[]
+    discardPile: readonly Card[]
+    exhaustPile: readonly Card[]
+  }>,
+): Player {
+  const health = Health.create(80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(0)
+
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: overrides.deck ?? [],
+    hand: overrides.hand ?? [],
+    discardPile: overrides.discardPile ?? [],
+    exhaustPile: overrides.exhaustPile ?? [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+/**
+ * IRandomService モック。
+ * shuffle はデフォルトで配列をそのまま返す（決定論的）。
+ * 必要に応じて vi.fn() で上書き可能。
+ */
+function makeRandomService(overrides?: Partial<IRandomService>): IRandomService {
+  return {
+    next: vi.fn(() => 0),
+    nextInt: vi.fn((min: number) => min),
+    shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+      ...array,
+    ]) as IRandomService['shuffle'],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────
+// drawCards
+// ─────────────────────────────────────────────
+
+describe('drawCards', () => {
+  describe('正常系 - 基本ドロー', () => {
+    it('AC1: ターン開始時に STARTING_DRAW_COUNT(5) 枚ドローできる', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(result.drawn).toHaveLength(STARTING_DRAW_COUNT)
+      expect(result.player.hand).toHaveLength(STARTING_DRAW_COUNT)
+    })
+
+    it('ドローしたカードは山札から除去される', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(result.player.deck).toHaveLength(10 - STARTING_DRAW_COUNT)
+    })
+
+    it('ドローしたカードは手札の先頭から追加される（既存手札との結合）', () => {
+      const existingHand = makeCards(2, 'hand')
+      const deck = makeCards(5, 'deck')
+      const player = makePlayer({ deck, hand: existingHand })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 3, random)
+
+      expect(result.player.hand).toHaveLength(5)
+    })
+
+    it('1枚だけドローできる（境界値：最小正常値）', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 1, random)
+
+      expect(result.drawn).toHaveLength(1)
+      expect(result.player.hand).toHaveLength(1)
+    })
+
+    it('山札と同数のカードをドローできる（境界値：ちょうど枚数）', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 5, random)
+
+      expect(result.drawn).toHaveLength(5)
+      expect(result.player.deck).toHaveLength(0)
+    })
+  })
+
+  describe('AC2: 山札が空になったとき捨て札をシャッフルして山札に戻す', () => {
+    it('山札が空で捨て札がある場合、捨て札がシャッフルされ山札になってからドローする', () => {
+      const discardPile = makeCards(8, 'discard')
+      const player = makePlayer({ deck: [], discardPile })
+      const shuffled = [...discardPile].reverse()
+      const random = makeRandomService({
+        shuffle: vi.fn(() => shuffled) as IRandomService['shuffle'],
+      })
+
+      const result = drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(random.shuffle).toHaveBeenCalledOnce()
+      expect(result.drawn).toHaveLength(STARTING_DRAW_COUNT)
+      expect(result.player.discardPile).toHaveLength(0)
+    })
+
+    it('山札が途中で空になった場合、残りを捨て札からシャッフルして補充しドローする', () => {
+      const deck = makeCards(2, 'deck')
+      const discardPile = makeCards(6, 'discard')
+      const player = makePlayer({ deck, discardPile })
+      const random = makeRandomService({
+        shuffle: vi.fn(<T>(arr: readonly T[]): readonly T[] => [
+          ...arr,
+        ]) as IRandomService['shuffle'],
+      })
+
+      const result = drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(result.drawn).toHaveLength(STARTING_DRAW_COUNT)
+    })
+
+    it('山札も捨て札も空の場合、ドロー枚数が不足してもエラーにならない', () => {
+      const player = makePlayer({ deck: [], discardPile: [] })
+      const random = makeRandomService()
+
+      const result = drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(result.drawn.length).toBeLessThan(STARTING_DRAW_COUNT)
+      expect(result.player.hand.length).toBe(result.drawn.length)
+    })
+
+    it('シャッフル後の捨て札は空になる', () => {
+      const discardPile = makeCards(5, 'discard')
+      const player = makePlayer({ deck: [], discardPile })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 3, random)
+
+      expect(result.player.discardPile).toHaveLength(0)
+    })
+  })
+
+  describe('AC6: 手札が MAX_HAND_SIZE(10) の場合、超過分はバーンされる', () => {
+    it('手札が MAX_HAND_SIZE のとき追加ドローしようとするとすべてバーンされる', () => {
+      const hand = makeCards(MAX_HAND_SIZE, 'hand')
+      const deck = makeCards(5, 'deck')
+      const player = makePlayer({ deck, hand })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 3, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+      expect(result.burned).toHaveLength(3)
+    })
+
+    it('手札が 9 枚で 3 枚ドローしようとすると 1 枚ドロー・2 枚バーン', () => {
+      const hand = makeCards(9, 'hand')
+      const deck = makeCards(5, 'deck')
+      const player = makePlayer({ deck, hand })
+      const random = makeRandomService()
+
+      const result = drawCards(player, 3, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+      expect(result.drawn).toHaveLength(1)
+      expect(result.burned).toHaveLength(2)
+    })
+
+    it('手札が 0 枚で MAX_HAND_SIZE 枚ドローするとちょうど満杯になる（境界値：最大正常値）', () => {
+      const deck = makeCards(MAX_HAND_SIZE + 2)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, MAX_HAND_SIZE, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+      expect(result.burned).toHaveLength(0)
+    })
+
+    it('手札が 0 枚で MAX_HAND_SIZE+1 枚ドローしようとすると 1 枚バーンされる', () => {
+      const deck = makeCards(MAX_HAND_SIZE + 2)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = drawCards(player, MAX_HAND_SIZE + 1, random)
+
+      expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
+      expect(result.burned).toHaveLength(1)
+    })
+  })
+
+  describe('イミュータビリティ', () => {
+    it('元の player オブジェクトを変更しない', () => {
+      const deck = makeCards(10)
+      const player = makePlayer({ deck })
+      const originalDeckLength = player.deck.length
+      const random = makeRandomService()
+
+      drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(player.deck).toHaveLength(originalDeckLength)
+      expect(player.hand).toHaveLength(0)
+    })
+
+    it('元の deck 配列を変更しない', () => {
+      const deck = makeCards(10)
+      const originalDeck = [...deck]
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      drawCards(player, STARTING_DRAW_COUNT, random)
+
+      expect(player.deck).toEqual(originalDeck)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// discardCard
+// ─────────────────────────────────────────────
+
+describe('discardCard', () => {
+  describe('正常系', () => {
+    it('手札のカードを捨て札に移せる', () => {
+      const card = makeCard('strike')
+      const hand = [card, makeCard('defend')]
+      const player = makePlayer({ hand })
+
+      const result = discardCard(player, makeCardId('strike'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.hand).toHaveLength(1)
+      expect(result.value.discardPile).toHaveLength(1)
+      expect(result.value.discardPile[0]!.id).toBe(makeCardId('strike'))
+    })
+
+    it('捨て札に移動したカードは手札に残らない', () => {
+      const card = makeCard('strike')
+      const player = makePlayer({ hand: [card] })
+
+      const result = discardCard(player, makeCardId('strike'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.hand).toHaveLength(0)
+    })
+
+    it('手札が 1 枚のとき捨て札に移すと手札が空になる（境界値：最小）', () => {
+      const card = makeCard('last_card')
+      const player = makePlayer({ hand: [card] })
+
+      const result = discardCard(player, makeCardId('last_card'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.hand).toHaveLength(0)
+      expect(result.value.discardPile).toHaveLength(1)
+    })
+
+    it('既存の捨て札に追加される（既存捨て札との結合）', () => {
+      const existingDiscard = makeCards(3, 'old')
+      const card = makeCard('new_card')
+      const player = makePlayer({ hand: [card], discardPile: existingDiscard })
+
+      const result = discardCard(player, makeCardId('new_card'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.discardPile).toHaveLength(4)
+    })
+  })
+
+  describe('異常系 - 存在しないカード参照', () => {
+    it('手札にないカードIDを指定すると not_in_hand エラーを返す', () => {
+      const player = makePlayer({ hand: makeCards(3) })
+
+      const result = discardCard(player, makeCardId('nonexistent_card'))
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_in_hand')
+    })
+
+    it('手札が空のとき discardCard を呼ぶと not_in_hand エラーを返す', () => {
+      const player = makePlayer({ hand: [] })
+
+      const result = discardCard(player, makeCardId('any_card'))
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_in_hand')
+    })
+  })
+
+  describe('イミュータビリティ', () => {
+    it('元の player オブジェクトを変更しない', () => {
+      const card = makeCard('strike')
+      const player = makePlayer({ hand: [card] })
+
+      discardCard(player, makeCardId('strike'))
+
+      expect(player.hand).toHaveLength(1)
+      expect(player.discardPile).toHaveLength(0)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// exhaustCard
+// ─────────────────────────────────────────────
+
+describe('exhaustCard', () => {
+  describe('AC3: 消耗カードがプレイ後に除外されデッキに戻らない', () => {
+    it('手札のカードを exhaustPile に移せる', () => {
+      const card = makeCard('exhaust_me')
+      const player = makePlayer({ hand: [card] })
+
+      const result = exhaustCard(player, makeCardId('exhaust_me'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.exhaustPile).toHaveLength(1)
+      expect(result.value.exhaustPile[0]!.id).toBe(makeCardId('exhaust_me'))
+    })
+
+    it('消耗したカードは手札から除去される', () => {
+      const card = makeCard('exhaust_me')
+      const player = makePlayer({ hand: [card] })
+
+      const result = exhaustCard(player, makeCardId('exhaust_me'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.hand).toHaveLength(0)
+    })
+
+    it('消耗したカードは捨て札に移動しない', () => {
+      const card = makeCard('exhaust_me')
+      const player = makePlayer({ hand: [card] })
+
+      const result = exhaustCard(player, makeCardId('exhaust_me'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.discardPile).toHaveLength(0)
+    })
+
+    it('消耗したカードは山札に戻らない', () => {
+      const card = makeCard('exhaust_me')
+      const player = makePlayer({ hand: [card], deck: makeCards(3, 'deck') })
+
+      const result = exhaustCard(player, makeCardId('exhaust_me'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.deck).toHaveLength(3)
+    })
+
+    it('既存の exhaustPile に追加される', () => {
+      const existingExhaust = makeCards(2, 'exhausted')
+      const card = makeCard('new_exhaust')
+      const player = makePlayer({ hand: [card], exhaustPile: existingExhaust })
+
+      const result = exhaustCard(player, makeCardId('new_exhaust'))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.exhaustPile).toHaveLength(3)
+    })
+  })
+
+  describe('異常系 - 存在しないカード参照', () => {
+    it('手札にないカードIDを指定すると not_in_hand エラーを返す', () => {
+      const player = makePlayer({ hand: makeCards(3) })
+
+      const result = exhaustCard(player, makeCardId('ghost_card'))
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_in_hand')
+    })
+
+    it('手札が空のとき exhaustCard を呼ぶと not_in_hand エラーを返す', () => {
+      const player = makePlayer({ hand: [] })
+
+      const result = exhaustCard(player, makeCardId('any_card'))
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_in_hand')
+    })
+  })
+
+  describe('イミュータビリティ', () => {
+    it('元の player オブジェクトを変更しない', () => {
+      const card = makeCard('exhaust_me')
+      const player = makePlayer({ hand: [card] })
+
+      exhaustCard(player, makeCardId('exhaust_me'))
+
+      expect(player.hand).toHaveLength(1)
+      expect(player.exhaustPile).toHaveLength(0)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// shuffleDeck
+// ─────────────────────────────────────────────
+
+describe('shuffleDeck', () => {
+  describe('正常系', () => {
+    it('シャッフルされた新しい山札を持つ Player を返す', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const shuffled = [...deck].reverse()
+      const random = makeRandomService({
+        shuffle: vi.fn(() => shuffled) as IRandomService['shuffle'],
+      })
+
+      const result = shuffleDeck(player, random)
+
+      expect(result.deck).toEqual(shuffled)
+    })
+
+    it('IRandomService.shuffle が 1 回呼ばれる', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      shuffleDeck(player, random)
+
+      expect(random.shuffle).toHaveBeenCalledOnce()
+      expect(random.shuffle).toHaveBeenCalledWith(deck)
+    })
+
+    it('空の山札に対してシャッフルしてもエラーにならない', () => {
+      const player = makePlayer({ deck: [] })
+      const random = makeRandomService()
+
+      const result = shuffleDeck(player, random)
+
+      expect(result.deck).toHaveLength(0)
+    })
+
+    it('1枚だけの山札をシャッフルできる（境界値：最小）', () => {
+      const deck = [makeCard('single_card')]
+      const player = makePlayer({ deck })
+      const random = makeRandomService()
+
+      const result = shuffleDeck(player, random)
+
+      expect(result.deck).toHaveLength(1)
+    })
+  })
+
+  describe('イミュータビリティ', () => {
+    it('元の player オブジェクトを変更しない', () => {
+      const deck = makeCards(5)
+      const player = makePlayer({ deck })
+      const original = [...deck]
+      const random = makeRandomService({
+        shuffle: vi.fn(
+          <T>(arr: readonly T[]): readonly T[] => [...arr].reverse() as readonly T[],
+        ) as IRandomService['shuffle'],
+      })
+
+      shuffleDeck(player, random)
+
+      expect(player.deck).toEqual(original)
+    })
+
+    it('他のフィールド（手札・捨て札等）は変更されない', () => {
+      const hand = makeCards(3, 'hand')
+      const discardPile = makeCards(2, 'discard')
+      const player = makePlayer({ deck: makeCards(5), hand, discardPile })
+      const random = makeRandomService()
+
+      const result = shuffleDeck(player, random)
+
+      expect(result.hand).toEqual(hand)
+      expect(result.discardPile).toEqual(discardPile)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `DeckRules`（domain/rules）: `drawCards` / `discardCard` / `exhaustCard` / `shuffleDeck` を純粋関数として実装
- `Effect` インターフェース + `EffectApplyResult` 基底型（application/effects）
- `DrawCardEffect`: `Effect` を実装、`drawCards` を呼び出してドローエフェクトを提供
- count バリデーション: `drawCards` は `RangeError`、`DrawCardEffect` コンストラクタは `Error`
- テスト 55 件追加（AC1〜AC6 全カバー）

## 受け入れ条件

| AC | 条件 | 対応箇所 |
|----|------|---------|
| AC1 | ターン開始時に STARTING_DRAW_COUNT(5) 枚ドロー | `drawCards(player, STARTING_DRAW_COUNT, random)` |
| AC2 | 山札空で捨て札シャッフル → 山札補充 | `drawCards` 内のリシャッフルロジック |
| AC3 | 消耗カードが exhaustPile に移動しデッキに戻らない | `exhaustCard` |
| AC4 | 操作結果が返り値に反映 | `DrawResult { player, drawn, burned }` |
| AC5 | ドローエフェクトで規定枚数ドロー | `DrawCardEffect.apply` |
| AC6 | 手札 10 枚で超過分バーン（捨て札行き） | `drawCards` のバーン処理 |

## Test plan

- [ ] `npm run typecheck` 通過を確認
- [ ] `npm run lint` 通過を確認
- [ ] `npm run test:run` 全 425 件通過を確認
- [ ] `drawCards` 正常ドロー・リシャッフル・バーンをレビュー
- [ ] `discardCard` / `exhaustCard` の Result 型戻り値をレビュー
- [ ] `DrawCardEffect` が `Effect` インターフェースを満たすことを確認

Closes #137