### PR TITLE
feat: T135 カードエフェクトエンジン実装

### DIFF
--- a/src/application/effects/BlockEffect.ts
+++ b/src/application/effects/BlockEffect.ts
@@ -1,0 +1,36 @@
+import {
+  type SelfEffect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from './Effect'
+import { setPlayerBlock } from '../../domain/rules/PlayerRules'
+
+/**
+ * ブロックエフェクト（アプリケーション層）
+ *
+ * カードをプレイしたときにプレイヤーにブロックを付与する（SelfEffect）。
+ * Block.add() を呼び出してイミュータブルに状態を更新する。
+ *
+ * - context.target を参照しない（プレイヤー自身に適用する）
+ * - amount は非負整数でなければならない（負数・小数はコンストラクタで弾く）
+ * - 敵状態（enemies）は変更しない
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export class BlockEffect implements SelfEffect {
+  readonly targetKind = 'player' as const
+
+  constructor(private readonly amount: number) {
+    if (!Number.isInteger(amount) || amount < 0) {
+      throw new Error(`BlockEffect: amount must be a non-negative integer, got ${amount}`)
+    }
+  }
+
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
+    void context // SelfEffect: プレイヤー自身に適用するためターゲット不要
+    void services // SelfEffect インターフェース互換のため省略不可（このエフェクトでは未使用）
+    const updatedBlock = state.player.block.add(this.amount)
+    return { ...state, player: setPlayerBlock(state.player, updatedBlock) }
+  }
+}

--- a/src/application/effects/DamageEffect.ts
+++ b/src/application/effects/DamageEffect.ts
@@ -1,0 +1,48 @@
+import {
+  type SingleTargetEffect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from './Effect'
+import { updateEnemy } from '../../domain/rules/EnemyRules'
+import { applyDamageToCharacter } from '../../domain/rules/CombatRules'
+
+/**
+ * ダメージエフェクト（アプリケーション層）
+ *
+ * カードをプレイしたときに単体の敵にダメージを与える（SingleTargetEffect）。
+ * ダメージはブロックで先に吸収され、残りが HP に適用される（domain/CombatRules に委譲）。
+ *
+ * - context.target.kind === 'enemy' を前提とする。それ以外はプログラマーバグ → throw
+ * - 全体攻撃（Cleave 等）は AllEnemiesEffect の実装クラスを別途用意する
+ * - target.id に対応する敵が enemies に存在しない場合は state をそのまま返す
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export class DamageEffect implements SingleTargetEffect {
+  readonly targetKind = 'enemy' as const
+
+  constructor(private readonly amount: number) {
+    if (!Number.isInteger(amount) || amount < 0) {
+      throw new Error(`DamageEffect: amount must be a non-negative integer, got ${amount}`)
+    }
+  }
+
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
+    void services // SingleTargetEffect インターフェース互換のため省略不可（このエフェクトでは未使用）
+    const { target } = context
+    if (!target || target.kind !== 'enemy') {
+      throw new Error(
+        `DamageEffect: context.target must be { kind: 'enemy', id } but got ${JSON.stringify(target)}`,
+      )
+    }
+
+    const result = updateEnemy(state.enemies, target.id, (enemy) =>
+      applyDamageToCharacter(enemy, this.amount),
+    )
+    // 対象敵が既に存在しない場合（先に倒れた等）は state をそのまま返す
+    const updatedEnemies = result.ok ? result.value : state.enemies
+
+    return { ...state, enemies: updatedEnemies }
+  }
+}

--- a/src/application/effects/DrawEffect.ts
+++ b/src/application/effects/DrawEffect.ts
@@ -1,25 +1,34 @@
-import { type Effect, type BattleState, type EffectServices } from './Effect'
+import {
+  type SelfEffect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from './Effect'
 import { drawCards } from '../../domain/rules/DeckRules'
 
 /**
  * ドローエフェクト（アプリケーション層）
  *
- * カードをプレイしたときに山札から count 枚ドローする。
+ * カードをプレイしたときに山札から count 枚ドローする（SelfEffect）。
  * DeckRules.drawCards() を呼び出してイミュータブルに状態を更新する。
  *
+ * - context.target を参照しない（プレイヤー自身に適用する）
  * - count は非負整数でなければならない（負数・小数はコンストラクタで弾く）
  * - 敵状態（enemies）は変更しない
  * - 参照可能な層: domain, application/effects のみ
  * - 参照してはいけない層: infrastructure, presentation
  */
-export class DrawCardEffect implements Effect {
+export class DrawEffect implements SelfEffect {
+  readonly targetKind = 'player' as const
+
   constructor(private readonly count: number) {
     if (!Number.isInteger(count) || count < 0) {
-      throw new Error(`DrawCardEffect: count must be a non-negative integer, got ${count}`)
+      throw new Error(`DrawEffect: count must be a non-negative integer, got ${count}`)
     }
   }
 
-  apply(state: BattleState, services: EffectServices): BattleState {
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
+    void context // SelfEffect: プレイヤー自身に適用するためターゲット不要
     const { player: updatedPlayer } = drawCards(state.player, this.count, services.random)
     return { ...state, player: updatedPlayer }
   }

--- a/src/application/effects/Effect.ts
+++ b/src/application/effects/Effect.ts
@@ -1,21 +1,21 @@
-import { type Player } from '../../domain/entities/Player'
-import { type Enemy } from '../../domain/entities/Enemy'
 import { type IRandomService } from '../../domain/interfaces/IRandomService'
+import { type Target } from '../../shared/types'
+import { type BattleState } from '../../domain/entities/BattleState'
+
+export type { BattleState }
 
 /**
- * エフェクト適用対象の戦闘状態（アプリケーション層）
+ * カードプレイ時の一時ターゲット情報（アプリケーション層）
  *
- * エフェクトが読み取り・更新する戦闘状態のスナップショット。
- * domain の Combat エンティティ（turn を含む）のサブセットとして設計し、
- * エフェクトが必要とする最小限の状態のみを保持する。
+ * BattleState（永続戦闘状態）とは異なり、カード1枚のプレイ時にのみ存在する
+ * 一時的なコンテキスト。エフェクトパイプライン全体を通じて変わらない。
  *
- * - turn は含まない（ターン数依存エフェクトが必要になった際に拡張する）
- * - EffectServices と分離することで「状態（何が変わるか）」と
- *   「サービス（どう変えるか）」の責務を明確にする
+ * - SingleTargetEffect は context.target.kind === 'enemy' を必要とする
+ * - AllEnemiesEffect は context.target.kind === 'all' を使用する
+ * - SelfEffect は context.target を参照しない
  */
-export interface BattleState {
-  readonly player: Player
-  readonly enemies: readonly Enemy[]
+export interface EffectContext {
+  readonly target?: Target
 }
 
 /**
@@ -23,25 +23,52 @@ export interface BattleState {
  *
  * 戦闘状態（BattleState）とは別に管理するサービスの集合。
  * エフェクトの入力にも出力にもならないため BattleState から分離する。
- * EffectExecutor（#135）がエフェクトパイプライン全体で使い回す。
  */
 export interface EffectServices {
   readonly random: IRandomService
 }
 
 /**
- * カードエフェクトのインターフェース（アプリケーション層）
+ * カードエフェクトの基底インターフェース（アプリケーション層）
  *
- * カード JSON の effects 配列から生成される実行可能なエフェクト単位。
- * EffectFactory が EffectDef → Effect[] に変換し、各エフェクトが apply() を通じて
- * 戦闘状態を更新する。
+ * apply() は純粋関数として実装する（副作用なし・イミュータブル）。
+ * EffectExecutor での利用イメージ:
+ *   effects.reduce((state, effect) => effect.apply(state, context, services), initialState)
  *
- * - apply() は純粋関数として実装する（副作用なし・イミュータブル）
- * - EffectExecutor での利用イメージ:
- *   effects.reduce((state, effect) => effect.apply(state, services), initialState)
- * - 参照可能な層: domain, application/effects
- * - 参照してはいけない層: infrastructure, presentation
+ * 参照可能な層: domain, application/effects
+ * 参照してはいけない層: infrastructure, presentation
  */
 export interface Effect {
-  apply(state: BattleState, services: EffectServices): BattleState
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState
+}
+
+/**
+ * 単体敵ターゲットエフェクト（アプリケーション層）
+ *
+ * context.target.kind === 'enemy' を前提とするエフェクト。
+ * DamageEffect 等、単体敵を対象とするカード効果に使用する。
+ * target が enemy 以外の場合はプログラマーバグとして throw する。
+ */
+export interface SingleTargetEffect extends Effect {
+  readonly targetKind: 'enemy'
+}
+
+/**
+ * 全体敵ターゲットエフェクト（アプリケーション層）
+ *
+ * context.target.kind === 'all' を前提とするエフェクト。
+ * Whirlwind / Cleave 等、全体攻撃カード効果に使用する。
+ */
+export interface AllEnemiesEffect extends Effect {
+  readonly targetKind: 'all'
+}
+
+/**
+ * プレイヤー自身へのエフェクト（アプリケーション層）
+ *
+ * context.target を参照しない。
+ * BlockEffect / DrawEffect 等、自身に効果を与えるカード効果に使用する。
+ */
+export interface SelfEffect extends Effect {
+  readonly targetKind: 'player'
 }

--- a/src/application/effects/EffectExecutor.ts
+++ b/src/application/effects/EffectExecutor.ts
@@ -1,0 +1,24 @@
+import { type Effect, type BattleState, type EffectContext, type EffectServices } from './Effect'
+
+/**
+ * エフェクトパイプライン実行関数（アプリケーション層）
+ *
+ * Effect[] を受け取り、順番に BattleState へ適用して最終状態を返す。
+ * 各エフェクトの出力が次のエフェクトの入力になる（パイプラインパターン）。
+ *
+ * - effects が空の場合は初期状態をそのまま返す
+ * - context はパイプライン全体で共有される（各エフェクトが参照）
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export function executeEffects(
+  effects: readonly Effect[],
+  state: BattleState,
+  context: EffectContext,
+  services: EffectServices,
+): BattleState {
+  return effects.reduce(
+    (currentState, effect) => effect.apply(currentState, context, services),
+    state,
+  )
+}

--- a/src/application/effects/EffectFactory.ts
+++ b/src/application/effects/EffectFactory.ts
@@ -1,0 +1,53 @@
+import { type EffectDef, type Result, ok, err } from '../../shared/types'
+import { type Effect } from './Effect'
+import { DamageEffect } from './DamageEffect'
+import { BlockEffect } from './BlockEffect'
+import { DrawEffect } from './DrawEffect'
+
+type EffectBuilder = (def: EffectDef) => Effect
+
+/**
+ * エフェクトビルダーレジストリ
+ *
+ * EffectDef.type → Effect インスタンス生成関数のマッピング。
+ * 新しいエフェクトタイプを追加する際はここにエントリを追加するだけでよい。
+ */
+const EFFECT_BUILDERS: Record<string, EffectBuilder> = {
+  damage: (def) => new DamageEffect(def.value),
+  block: (def) => new BlockEffect(def.value),
+  draw: (def) => new DrawEffect(def.value),
+}
+
+/**
+ * エフェクトファクトリ（アプリケーション層）
+ *
+ * カード JSON の effects 配列（EffectDef[]）を実行可能な Effect[] に変換する。
+ *
+ * - 成功時: ok(Effect[]) を返す
+ * - 未知タイプ・不正値があった場合: err(errors) を返す（エラー内容を文字列配列で通知）
+ * - Error 以外の予期しない例外は再スローしてプログラマーバグを隠さない
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export class EffectFactory {
+  static build(defs: readonly EffectDef[]): Result<Effect[], string[]> {
+    const effects: Effect[] = []
+    const errors: string[] = []
+
+    for (const def of defs) {
+      const builder = EFFECT_BUILDERS[def.type]
+      if (!builder) {
+        errors.push(`Unknown effect type: "${def.type}"`)
+        continue
+      }
+      try {
+        effects.push(builder(def))
+      } catch (e) {
+        if (!(e instanceof Error)) throw e
+        errors.push(`Failed to build effect "${def.type}": ${e.message}`)
+      }
+    }
+
+    return errors.length > 0 ? err(errors) : ok(effects)
+  }
+}

--- a/src/domain/entities/BattleState.ts
+++ b/src/domain/entities/BattleState.ts
@@ -1,0 +1,20 @@
+import { type Player } from './Player'
+import { type Enemy } from './Enemy'
+
+/**
+ * エフェクト適用対象の戦闘状態（ドメイン層）
+ *
+ * エフェクトが読み取り・更新する戦闘状態のスナップショット。
+ * Player・Enemy の現在状態を保持する不変オブジェクト。
+ *
+ * - target（カードプレイ時の一時ターゲット）は含まない
+ *   → EffectContext として別途渡す（application 層の責務）
+ * - turn・phase 等の戦闘進行情報は将来必要に応じて拡張する
+ *
+ * 参照可能な層: domain, application
+ * 参照してはいけない層: infrastructure, presentation
+ */
+export interface BattleState {
+  readonly player: Player
+  readonly enemies: readonly Enemy[]
+}

--- a/src/domain/rules/CombatRules.ts
+++ b/src/domain/rules/CombatRules.ts
@@ -1,0 +1,19 @@
+import { type Combatant } from '../entities/Character'
+
+/**
+ * キャラクターにダメージを適用した新しいインスタンスを返す（純粋関数）。
+ *
+ * ダメージはブロックで先に吸収され、残りが HP に適用される（ブロック先行消費ルール）。
+ * Player・Enemy 双方で再利用可能な汎用ダメージ計算。
+ *
+ * @param combatant - ダメージを受けるキャラクター（イミュータブル）
+ * @param amount    - ダメージ量（非負整数）
+ * @returns 更新後の新しいキャラクターオブジェクト
+ *
+ * 参照可能な層: domain/entities のみ
+ */
+export function applyDamageToCharacter<T extends Combatant>(combatant: T, amount: number): T {
+  const { block, remainingDamage } = combatant.block.absorb(amount)
+  const health = combatant.health.takeDamage(remainingDamage)
+  return { ...combatant, block, health }
+}

--- a/src/domain/rules/EnemyRules.ts
+++ b/src/domain/rules/EnemyRules.ts
@@ -1,0 +1,26 @@
+import { type Enemy } from '../entities/Enemy'
+import { type Result, ok, err } from '../../shared/types'
+
+/**
+ * 指定 id の敵のみを更新した新しい enemies 配列を返す（純粋関数）。
+ *
+ * 対象が存在しない場合は ok: false を返す（サイレント no-op を防ぐ）。
+ * updater が返す Enemy のスプレッド再構築はこの関数に集約し、
+ * 各エフェクトが直接 map を書くことを避ける。
+ *
+ * @param enemies  - 現在の敵一覧（イミュータブル）
+ * @param targetId - 更新対象の敵インスタンス id（Character.id）
+ * @param updater  - 対象敵を受け取り更新後の敵を返す純粋関数
+ * @returns ok: 更新後の配列、err: 'enemy_not_found'（対象敵が存在しない場合）
+ *
+ * 参照可能な層: domain/entities のみ
+ */
+export function updateEnemy(
+  enemies: readonly Enemy[],
+  targetId: string,
+  updater: (enemy: Enemy) => Enemy,
+): Result<readonly Enemy[], 'enemy_not_found'> {
+  const found = enemies.some((e) => e.id === targetId)
+  if (!found) return err('enemy_not_found')
+  return ok(enemies.map((e) => (e.id === targetId ? updater(e) : e)))
+}

--- a/src/domain/rules/PlayerRules.ts
+++ b/src/domain/rules/PlayerRules.ts
@@ -1,0 +1,18 @@
+import { type Player } from '../entities/Player'
+import { type Block } from '../value-objects/Block'
+
+/**
+ * プレイヤーのブロック値を更新した新しい Player を返す（純粋関数）。
+ *
+ * BlockEffect が直接 spread しないよう domain ルールとして集約する。
+ * 将来的にブロック付与時の Power 発動（Juggernaut 等）もここに追加できる。
+ *
+ * @param player - 現在のプレイヤー（イミュータブル）
+ * @param block  - 新しいブロック値
+ * @returns 更新後の新しい Player オブジェクト
+ *
+ * 参照可能な層: domain/entities のみ
+ */
+export function setPlayerBlock(player: Player, block: Block): Player {
+  return { ...player, block }
+}

--- a/tests/application/effects/BlockEffect.test.ts
+++ b/tests/application/effects/BlockEffect.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from 'vitest'
+import { BlockEffect } from '../../../src/application/effects/BlockEffect'
+import {
+  type Effect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from '../../../src/application/effects/Effect'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeEnemy(id: string): Enemy {
+  const hp = Health.create(50, 50)
+  const block = Block.create(0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makePlayer(
+  overrides?: Partial<{ currentHp: number; maxHp: number; block: number }>,
+): Player {
+  const health = Health.create(overrides?.currentHp ?? 80, overrides?.maxHp ?? 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makeServices(): EffectServices {
+  return {
+    random: {
+      next: vi.fn(() => 0),
+      nextInt: vi.fn((min: number) => min),
+      shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+        ...array,
+      ]) as IRandomService['shuffle'],
+    },
+  }
+}
+
+function makeBattleState(player: Player, enemies: readonly Enemy[] = []): BattleState {
+  return { player, enemies }
+}
+
+function makeContext(): EffectContext {
+  return {}
+}
+
+// ─────────────────────────────────────────────
+// BlockEffect — インターフェース適合
+// ─────────────────────────────────────────────
+
+describe('BlockEffect - Effect インターフェース適合', () => {
+  it('Effect インターフェースを実装している', () => {
+    const effect: Effect = new BlockEffect(5)
+    expect(effect).toBeDefined()
+  })
+
+  it('正の整数値で構築できる', () => {
+    const effect = new BlockEffect(5)
+    expect(effect).toBeInstanceOf(BlockEffect)
+  })
+})
+
+// ─────────────────────────────────────────────
+// BlockEffect — 生成・コンストラクタ (AC3, 観点05/07/10)
+// ─────────────────────────────────────────────
+
+describe('BlockEffect - 生成', () => {
+  it('value=0 で正常に生成できる（境界値：最小正常値）', () => {
+    expect(() => new BlockEffect(0)).not.toThrow()
+  })
+
+  it('value=1 で正常に生成できる', () => {
+    expect(() => new BlockEffect(1)).not.toThrow()
+  })
+
+  it('value=999 で正常に生成できる（大きな値）', () => {
+    expect(() => new BlockEffect(999)).not.toThrow()
+  })
+
+  it('value が負のとき生成時にエラーを投げる（下限違反）', () => {
+    expect(() => new BlockEffect(-1)).toThrow()
+  })
+
+  it('value が NaN のとき生成時にエラーを投げる', () => {
+    expect(() => new BlockEffect(NaN)).toThrow()
+  })
+
+  it('value が Infinity のとき生成時にエラーを投げる', () => {
+    expect(() => new BlockEffect(Infinity)).toThrow()
+  })
+
+  it('value が -Infinity のとき生成時にエラーを投げる', () => {
+    expect(() => new BlockEffect(-Infinity)).toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────
+// BlockEffect.apply — 正常系 (AC1, 観点01/02)
+// ─────────────────────────────────────────────
+
+describe('BlockEffect.apply - 正常系', () => {
+  describe('AC1: プレイヤーにブロックが付与される', () => {
+    it('value=5 のときプレイヤーのブロックが 5 増える', () => {
+      const player = makePlayer({ block: 0 })
+      const state = makeBattleState(player)
+      const effect = new BlockEffect(5)
+
+      const result = effect.apply(state, makeContext(), makeServices())
+
+      expect(result.player.block.value).toBe(5)
+    })
+
+    it('既存のブロックに加算される', () => {
+      const player = makePlayer({ block: 3 })
+      const state = makeBattleState(player)
+      const effect = new BlockEffect(5)
+
+      const result = effect.apply(state, makeContext(), makeServices())
+
+      expect(result.player.block.value).toBe(8)
+    })
+
+    it('value=0 のとき既存ブロックは変わらない（境界値）', () => {
+      const player = makePlayer({ block: 5 })
+      const state = makeBattleState(player)
+      const effect = new BlockEffect(0)
+
+      const result = effect.apply(state, makeContext(), makeServices())
+
+      expect(result.player.block.value).toBe(5)
+    })
+
+    it('value=1 のとき既存ブロックに 1 加算（最小加算）', () => {
+      const player = makePlayer({ block: 0 })
+      const state = makeBattleState(player)
+      const effect = new BlockEffect(1)
+
+      const result = effect.apply(state, makeContext(), makeServices())
+
+      expect(result.player.block.value).toBe(1)
+    })
+  })
+
+  describe('AC1: 敵に影響を与えない', () => {
+    it('BlockEffect は enemies を変更しない', () => {
+      const player = makePlayer()
+      const enemy = makeEnemy('jaw_worm')
+      const state = makeBattleState(player, [enemy])
+      const effect = new BlockEffect(5)
+
+      const result = effect.apply(state, makeContext(), makeServices())
+
+      expect(result.enemies).toBe(state.enemies)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// BlockEffect.apply — イミュータビリティ (観点11)
+// ─────────────────────────────────────────────
+
+describe('BlockEffect.apply - イミュータビリティ', () => {
+  it('apply は元の BattleState を変更しない', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(5)
+    const originalBlockValue = state.player.block.value
+
+    effect.apply(state, makeContext(), makeServices())
+
+    expect(state.player.block.value).toBe(originalBlockValue)
+  })
+
+  it('apply は元の player オブジェクトを変更せず新しいオブジェクトを返す', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(5)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player).not.toBe(state.player)
+  })
+
+  it('apply は元の player.block オブジェクトを変更しない', () => {
+    const player = makePlayer({ block: 3 })
+    const originalBlock = player.block
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(5)
+
+    effect.apply(state, makeContext(), makeServices())
+
+    expect(originalBlock.value).toBe(3)
+  })
+})
+
+// ─────────────────────────────────────────────
+// BlockEffect.apply — BattleState への反映 (AC5)
+// ─────────────────────────────────────────────
+
+describe('BlockEffect.apply - BattleState への反映', () => {
+  it('apply の戻り値に更新後の player が含まれる', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(7)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(7)
+    expect(result.player).not.toBe(player)
+  })
+
+  it('apply の戻り値は新しい BattleState オブジェクト', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(5)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result).not.toBe(state)
+  })
+})

--- a/tests/application/effects/DamageEffect.test.ts
+++ b/tests/application/effects/DamageEffect.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DamageEffect } from '../../../src/application/effects/DamageEffect'
+import {
+  type Effect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from '../../../src/application/effects/Effect'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type Target } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{ currentHp: number; maxHp: number; block: number }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makePlayer(): Player {
+  const health = Health.create(80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makeServices(): EffectServices {
+  return {
+    random: {
+      next: vi.fn(() => 0),
+      nextInt: vi.fn((min: number) => min),
+      shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+        ...array,
+      ]) as IRandomService['shuffle'],
+    },
+  }
+}
+
+function makeBattleState(enemies: readonly Enemy[], player?: Player): BattleState {
+  return {
+    player: player ?? makePlayer(),
+    enemies,
+  }
+}
+
+function makeContext(target?: Target): EffectContext {
+  return { target }
+}
+
+// ─────────────────────────────────────────────
+// DamageEffect — インターフェース適合
+// ─────────────────────────────────────────────
+
+describe('DamageEffect - Effect インターフェース適合', () => {
+  it('Effect インターフェースを実装している', () => {
+    const effect: Effect = new DamageEffect(6)
+    expect(effect).toBeDefined()
+  })
+
+  it('正の整数値で構築できる', () => {
+    const effect = new DamageEffect(6)
+    expect(effect).toBeInstanceOf(DamageEffect)
+  })
+
+  it('targetKind が "enemy" である', () => {
+    const effect = new DamageEffect(6)
+    expect(effect.targetKind).toBe('enemy')
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect — 生成・コンストラクタ (AC3, 観点05/07/10)
+// ─────────────────────────────────────────────
+
+describe('DamageEffect - 生成', () => {
+  it('value=0 で正常に生成できる（境界値：最小正常値）', () => {
+    expect(() => new DamageEffect(0)).not.toThrow()
+  })
+
+  it('value=1 で正常に生成できる', () => {
+    expect(() => new DamageEffect(1)).not.toThrow()
+  })
+
+  it('value=999 で正常に生成できる（大きな値）', () => {
+    expect(() => new DamageEffect(999)).not.toThrow()
+  })
+
+  it('value が負のとき生成時にエラーを投げる（下限違反）', () => {
+    expect(() => new DamageEffect(-1)).toThrow()
+  })
+
+  it('value が NaN のとき生成時にエラーを投げる', () => {
+    expect(() => new DamageEffect(NaN)).toThrow()
+  })
+
+  it('value が Infinity のとき生成時にエラーを投げる', () => {
+    expect(() => new DamageEffect(Infinity)).toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — 正常系 (AC1, 観点01/11/16)
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - 正常系', () => {
+  describe('AC1: 対象敵にダメージが適用される', () => {
+    it('target.kind=enemy で指定した敵のHPが減る', () => {
+      const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy])
+      const effect = new DamageEffect(10)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      expect(resultEnemy?.health.current).toBe(40)
+    })
+
+    it('複数敵がいるとき対象の敵のみHPが減る', () => {
+      const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+      const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy1, enemy2])
+      const effect = new DamageEffect(10)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy1 = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      const resultEnemy2 = result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))
+      expect(resultEnemy1?.health.current).toBe(40)
+      expect(resultEnemy2?.health.current).toBe(30)
+    })
+  })
+
+  describe('AC1: ブロックを持つ敵へのダメージ（ブロック吸収）', () => {
+    it('blockがdamageより大きいとき敵HPは減らずブロックが減る', () => {
+      const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 20 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy])
+      const effect = new DamageEffect(10)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      expect(resultEnemy?.health.current).toBe(50)
+      expect(resultEnemy?.block.value).toBe(10)
+    })
+
+    it('blockがdamageより小さいとき残りダメージがHPに適用される', () => {
+      const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 5 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy])
+      const effect = new DamageEffect(10)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      expect(resultEnemy?.health.current).toBe(45)
+      expect(resultEnemy?.block.value).toBe(0)
+    })
+
+    it('blockがdamageと等しいとき敵HPは減らずブロックは0になる', () => {
+      const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 10 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy])
+      const effect = new DamageEffect(10)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      expect(resultEnemy?.health.current).toBe(50)
+      expect(resultEnemy?.block.value).toBe(0)
+    })
+  })
+
+  describe('AC1: ダメージ値=0 (境界値)', () => {
+    it('value=0 のとき敵のHPとブロックは変わらない', () => {
+      const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 5 })
+      const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+      const state = makeBattleState([enemy])
+      const effect = new DamageEffect(0)
+
+      const result = effect.apply(state, makeContext(target), makeServices())
+
+      const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      expect(resultEnemy?.health.current).toBe(50)
+      expect(resultEnemy?.block.value).toBe(5)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — ターゲット異常系 (AC3, 観点10)
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - ターゲット異常系（プログラマーバグ）', () => {
+  it('context.target が未設定のときエラーを投げる', () => {
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    expect(() => effect.apply(state, makeContext(), makeServices())).toThrow()
+  })
+
+  it('context.target.kind が player のときエラーを投げる', () => {
+    const enemy = makeEnemy('jaw_worm')
+    const target: Target = { kind: 'player' }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    expect(() => effect.apply(state, makeContext(target), makeServices())).toThrow()
+  })
+
+  it('context.target.kind が all のときエラーを投げる', () => {
+    const enemy = makeEnemy('jaw_worm')
+    const target: Target = { kind: 'all' }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    expect(() => effect.apply(state, makeContext(target), makeServices())).toThrow()
+  })
+
+  it('target.id が enemies に存在しないとき state をそのまま返す', () => {
+    const enemy = makeEnemy('jaw_worm')
+    const target: Target = { kind: 'enemy', id: makeEnemyId('unknown_enemy') }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    expect(result.enemies[0]?.health.current).toBe(50)
+    expect(result).toStrictEqual(state)
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — イミュータビリティ (観点11)
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - イミュータビリティ', () => {
+  it('apply は元の BattleState を変更しない', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+    const originalHp = state.enemies[0]?.health.current
+
+    effect.apply(state, makeContext(target), makeServices())
+
+    expect(state.enemies[0]?.health.current).toBe(originalHp)
+  })
+
+  it('apply は元の Enemy オブジェクトを変更せず新しいオブジェクトを返す', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    expect(result.enemies[0]).not.toBe(state.enemies[0])
+  })
+
+  it('apply は player を変更しない', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayer()
+    const state = makeBattleState([enemy], player)
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    expect(result.player).toBe(state.player)
+  })
+})

--- a/tests/application/effects/DrawEffect.test.ts
+++ b/tests/application/effects/DrawEffect.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
-import { DrawCardEffect } from '../../../src/application/effects/DrawCardEffect'
+import { DrawEffect } from '../../../src/application/effects/DrawEffect'
 import {
   type Effect,
   type BattleState,
+  type EffectContext,
   type EffectServices,
 } from '../../../src/application/effects/Effect'
 import { type Player } from '../../../src/domain/entities/Player'
@@ -98,60 +99,64 @@ function makeBattleState(player: Player, overrides?: Partial<BattleState>): Batt
   return { player, enemies: [], ...overrides }
 }
 
+function makeContext(): EffectContext {
+  return {}
+}
+
 // ─────────────────────────────────────────────
-// DrawCardEffect — 型確認
+// DrawEffect — 型確認
 // ─────────────────────────────────────────────
 
-describe('DrawCardEffect - Effect インターフェース適合', () => {
+describe('DrawEffect - Effect インターフェース適合', () => {
   it('Effect インターフェースを実装している', () => {
-    const effect: Effect = new DrawCardEffect(1)
+    const effect: Effect = new DrawEffect(1)
     expect(effect).toBeDefined()
   })
 
   it('count が正の整数で構築できる', () => {
-    const effect = new DrawCardEffect(3)
-    expect(effect).toBeInstanceOf(DrawCardEffect)
+    const effect = new DrawEffect(3)
+    expect(effect).toBeInstanceOf(DrawEffect)
   })
 })
 
 // ─────────────────────────────────────────────
-// DrawCardEffect.apply — AC5: ドローエフェクトを持つカードをプレイ
+// DrawEffect.apply — AC5: ドローエフェクトを持つカードをプレイ
 // ─────────────────────────────────────────────
 
-describe('DrawCardEffect.apply', () => {
+describe('DrawEffect.apply', () => {
   describe('AC5: ドローエフェクトで規定枚数のカードが手札に加わる', () => {
     it('count=2 のとき手札が 2 枚増える', () => {
       const player = makePlayer({ deck: makeCards(10) })
-      const effect = new DrawCardEffect(2)
+      const effect = new DrawEffect(2)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(2)
     })
 
     it('count=1 のとき手札が 1 枚増える（境界値：最小）', () => {
       const player = makePlayer({ deck: makeCards(5) })
-      const effect = new DrawCardEffect(1)
+      const effect = new DrawEffect(1)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(1)
     })
 
     it('count=5 のとき手札が 5 枚増える', () => {
       const player = makePlayer({ deck: makeCards(10) })
-      const effect = new DrawCardEffect(5)
+      const effect = new DrawEffect(5)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(5)
     })
 
     it('ドロー後に山札の枚数が減る', () => {
       const player = makePlayer({ deck: makeCards(10) })
-      const effect = new DrawCardEffect(3)
+      const effect = new DrawEffect(3)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.deck).toHaveLength(7)
     })
@@ -163,9 +168,9 @@ describe('DrawCardEffect.apply', () => {
       const shuffleMock = vi.fn(<T>(arr: readonly T[]): readonly T[] => [
         ...arr,
       ]) as IRandomService['shuffle']
-      const effect = new DrawCardEffect(3)
+      const effect = new DrawEffect(3)
 
-      const result = effect.apply(makeBattleState(player), makeServices({ shuffle: shuffleMock }))
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices({ shuffle: shuffleMock }))
 
       expect(result.player.hand).toHaveLength(3)
       expect(shuffleMock).toHaveBeenCalledOnce()
@@ -178,18 +183,18 @@ describe('DrawCardEffect.apply', () => {
         deck: makeCards(5, 'deck'),
         hand: makeCards(MAX_HAND_SIZE, 'hand'),
       })
-      const effect = new DrawCardEffect(2)
+      const effect = new DrawEffect(2)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
     })
 
     it('手札が 9 枚で 3 枚 draw すると 1 枚ドロー・2 枚バーン', () => {
       const player = makePlayer({ deck: makeCards(5, 'deck'), hand: makeCards(9, 'hand') })
-      const effect = new DrawCardEffect(3)
+      const effect = new DrawEffect(3)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(MAX_HAND_SIZE)
     })
@@ -198,20 +203,20 @@ describe('DrawCardEffect.apply', () => {
   describe('AC4: デッキ操作の結果が BattleState に反映される', () => {
     it('apply の戻り値に更新後の player が含まれる', () => {
       const player = makePlayer({ deck: makeCards(5) })
-      const effect = new DrawCardEffect(2)
+      const effect = new DrawEffect(2)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player).not.toBe(player)
       expect(result.player.hand).toHaveLength(2)
     })
 
-    it('apply は enemies を変更しない（DrawCardEffect はプレイヤーのみ変更）', () => {
+    it('apply は enemies を変更しない（DrawEffect はプレイヤーのみ変更）', () => {
       const player = makePlayer({ deck: makeCards(5) })
       const state = makeBattleState(player)
-      const effect = new DrawCardEffect(2)
+      const effect = new DrawEffect(2)
 
-      const result = effect.apply(state, makeServices())
+      const result = effect.apply(state, makeContext(), makeServices())
 
       expect(result.enemies).toBe(state.enemies)
     })
@@ -222,9 +227,9 @@ describe('DrawCardEffect.apply', () => {
       const player = makePlayer({ deck: makeCards(10) })
       const originalDeckLength = player.deck.length
       const originalHandLength = player.hand.length
-      const effect = new DrawCardEffect(3)
+      const effect = new DrawEffect(3)
 
-      effect.apply(makeBattleState(player), makeServices())
+      effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(player.deck).toHaveLength(originalDeckLength)
       expect(player.hand).toHaveLength(originalHandLength)
@@ -234,40 +239,40 @@ describe('DrawCardEffect.apply', () => {
   describe('異常系 - 不正な count', () => {
     it('count=0 で apply すると手札が増えない', () => {
       const player = makePlayer({ deck: makeCards(5) })
-      const effect = new DrawCardEffect(0)
+      const effect = new DrawEffect(0)
 
-      const result = effect.apply(makeBattleState(player), makeServices())
+      const result = effect.apply(makeBattleState(player), makeContext(), makeServices())
 
       expect(result.player.hand).toHaveLength(0)
     })
 
     it('山札も捨て札も空のとき apply してもエラーにならない', () => {
       const player = makePlayer({ deck: [], discardPile: [] })
-      const effect = new DrawCardEffect(3)
+      const effect = new DrawEffect(3)
 
-      expect(() => effect.apply(makeBattleState(player), makeServices())).not.toThrow()
+      expect(() => effect.apply(makeBattleState(player), makeContext(), makeServices())).not.toThrow()
     })
   })
 })
 
 // ─────────────────────────────────────────────
-// DrawCardEffect — Factoryパターン観点
+// DrawEffect — Factoryパターン観点
 // ─────────────────────────────────────────────
 
-describe('DrawCardEffect - Factory / 生成', () => {
+describe('DrawEffect - Factory / 生成', () => {
   it('count=1 で正常に生成できる（最小正常値）', () => {
-    expect(() => new DrawCardEffect(1)).not.toThrow()
+    expect(() => new DrawEffect(1)).not.toThrow()
   })
 
   it('count=MAX_HAND_SIZE で正常に生成できる（最大正常値）', () => {
-    expect(() => new DrawCardEffect(MAX_HAND_SIZE)).not.toThrow()
+    expect(() => new DrawEffect(MAX_HAND_SIZE)).not.toThrow()
   })
 
   it('count が負のとき生成時にエラーを投げる', () => {
-    expect(() => new DrawCardEffect(-1)).toThrow()
+    expect(() => new DrawEffect(-1)).toThrow()
   })
 
   it('count が非整数（小数）のとき生成時にエラーを投げる', () => {
-    expect(() => new DrawCardEffect(1.5)).toThrow()
+    expect(() => new DrawEffect(1.5)).toThrow()
   })
 })

--- a/tests/application/effects/EffectExecutor.test.ts
+++ b/tests/application/effects/EffectExecutor.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi } from 'vitest'
+import { executeEffects } from '../../../src/application/effects/EffectExecutor'
+import { DamageEffect } from '../../../src/application/effects/DamageEffect'
+import { BlockEffect } from '../../../src/application/effects/BlockEffect'
+import { DrawEffect } from '../../../src/application/effects/DrawEffect'
+import {
+  type Effect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from '../../../src/application/effects/Effect'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type Target } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+import { CardType } from '../../../src/domain/enums/CardType'
+import { Rarity } from '../../../src/domain/enums/Rarity'
+import { TargetType } from '../../../src/domain/enums/TargetType'
+import { type CardId } from '../../../src/shared/types'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{ currentHp: number; maxHp: number; block: number }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makeCardId(id: string): CardId {
+  return id as CardId
+}
+
+function makeCards(count: number, prefix = 'card') {
+  return Array.from({ length: count }, (_, i) => ({
+    id: makeCardId(`${prefix}_${i}`),
+    name: `${prefix}_${i}`,
+    description: `${prefix}_${i} description`,
+    cost: 1,
+    type: CardType.Attack,
+    rarity: Rarity.Common,
+    targetType: TargetType.Single,
+    effects: [],
+    upgraded: false,
+  }))
+}
+
+function makePlayer(overrides?: Partial<{ block: number; deckSize: number }>): Player {
+  const health = Health.create(80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: makeCards(overrides?.deckSize ?? 5),
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+function makeServices(): EffectServices {
+  return {
+    random: {
+      next: vi.fn(() => 0),
+      nextInt: vi.fn((min: number) => min),
+      shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [...array]) as IRandomService['shuffle'],
+    },
+  }
+}
+
+function makeBattleState(player: Player, enemies: readonly Enemy[] = []): BattleState {
+  return { player, enemies }
+}
+
+function makeContext(target?: Target): EffectContext {
+  return { target }
+}
+
+// ─────────────────────────────────────────────
+// executeEffects — 基本動作 (AC1)
+// ─────────────────────────────────────────────
+
+describe('executeEffects - 基本動作', () => {
+  it('エフェクトが空のとき初期 state をそのまま返す', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+
+    const result = executeEffects([], state, makeContext(), makeServices())
+
+    expect(result).toStrictEqual(state)
+  })
+
+  it('単一の BlockEffect が実行される', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+
+    const result = executeEffects([new BlockEffect(5)], state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(5)
+  })
+
+  it('単一の DrawEffect が実行される', () => {
+    const player = makePlayer({ deckSize: 5 })
+    const state = makeBattleState(player)
+
+    const result = executeEffects([new DrawEffect(2)], state, makeContext(), makeServices())
+
+    expect(result.player.hand).toHaveLength(2)
+  })
+})
+
+// ─────────────────────────────────────────────
+// executeEffects — 複数エフェクトの順番実行 (AC1, AC2)
+// ─────────────────────────────────────────────
+
+describe('executeEffects - 複数エフェクトの順番実行', () => {
+  it('AC2: 複数エフェクトが全て実行される（DamageEffect + BlockEffect）', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player, [enemy])
+
+    const result = executeEffects(
+      [new DamageEffect(10), new BlockEffect(5)],
+      state,
+      makeContext(target),
+      makeServices(),
+    )
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(40)
+    expect(result.player.block.value).toBe(5)
+  })
+
+  it('AC2: 複数エフェクトが全て実行される（BlockEffect + DrawEffect）', () => {
+    const player = makePlayer({ block: 0, deckSize: 5 })
+    const state = makeBattleState(player)
+
+    const result = executeEffects(
+      [new BlockEffect(5), new DrawEffect(2)],
+      state,
+      makeContext(),
+      makeServices(),
+    )
+
+    expect(result.player.block.value).toBe(5)
+    expect(result.player.hand).toHaveLength(2)
+  })
+
+  it('エフェクトが順番に適用される（前のエフェクト結果が次のエフェクトに引き継がれる）', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+
+    const result = executeEffects(
+      [new BlockEffect(5), new BlockEffect(3)],
+      state,
+      makeContext(),
+      makeServices(),
+    )
+
+    expect(result.player.block.value).toBe(8)
+  })
+
+  it('3つのエフェクトが全て順番に実行される', () => {
+    const player = makePlayer({ block: 0, deckSize: 10 })
+    const state = makeBattleState(player)
+
+    const result = executeEffects(
+      [new BlockEffect(5), new BlockEffect(3), new DrawEffect(1)],
+      state,
+      makeContext(),
+      makeServices(),
+    )
+
+    expect(result.player.block.value).toBe(8)
+    expect(result.player.hand).toHaveLength(1)
+  })
+})
+
+// ─────────────────────────────────────────────
+// executeEffects — AC1: カードをプレイするとエフェクトが順番に実行される
+// ─────────────────────────────────────────────
+
+describe('executeEffects - AC1: カードプレイシミュレーション', () => {
+  it('DamageEffect + DrawEffect で攻撃してドロー（攻撃カードのシミュレーション）', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayer({ deckSize: 5 })
+    const state = makeBattleState(player, [enemy])
+
+    const result = executeEffects(
+      [new DamageEffect(6), new DrawEffect(1)],
+      state,
+      makeContext(target),
+      makeServices(),
+    )
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(44)
+    expect(result.player.hand).toHaveLength(1)
+  })
+})
+
+// ─────────────────────────────────────────────
+// executeEffects — イミュータビリティ (観点11)
+// ─────────────────────────────────────────────
+
+describe('executeEffects - イミュータビリティ', () => {
+  it('executeEffects は元の BattleState を変更しない', () => {
+    const player = makePlayer({ block: 0 })
+    const state = makeBattleState(player)
+    const originalBlockValue = state.player.block.value
+
+    executeEffects([new BlockEffect(5)], state, makeContext(), makeServices())
+
+    expect(state.player.block.value).toBe(originalBlockValue)
+  })
+
+  it('executeEffects の戻り値は新しい BattleState オブジェクト', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+
+    const result = executeEffects([new BlockEffect(5)], state, makeContext(), makeServices())
+
+    expect(result).not.toBe(state)
+  })
+})
+
+// ─────────────────────────────────────────────
+// executeEffects — モック経由での実行確認
+// ─────────────────────────────────────────────
+
+describe('executeEffects - モックエフェクトによる実行確認', () => {
+  it('各エフェクトの apply が1回ずつ呼ばれる', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+    const services = makeServices()
+    const context = makeContext()
+
+    const mockEffect1: Effect = { apply: vi.fn((s) => s) }
+    const mockEffect2: Effect = { apply: vi.fn((s) => s) }
+
+    executeEffects([mockEffect1, mockEffect2], state, context, services)
+
+    expect(mockEffect1.apply).toHaveBeenCalledTimes(1)
+    expect(mockEffect2.apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('エフェクトが順番に呼ばれる（前の戻り値が次の入力になる）', () => {
+    const player = makePlayer()
+    const initialState = makeBattleState(player)
+    const services = makeServices()
+    const context = makeContext()
+
+    const intermediateState: BattleState = { ...initialState }
+    const finalState: BattleState = { ...initialState }
+
+    const mockEffect1: Effect = { apply: vi.fn(() => intermediateState) }
+    const mockEffect2: Effect = { apply: vi.fn(() => finalState) }
+
+    const result = executeEffects([mockEffect1, mockEffect2], initialState, context, services)
+
+    // effect1 は initialState を受け取る
+    expect(mockEffect1.apply).toHaveBeenCalledWith(initialState, context, services)
+    // effect2 は effect1 の戻り値（intermediateState）を受け取る
+    expect(mockEffect2.apply).toHaveBeenCalledWith(intermediateState, context, services)
+    // 最終結果は effect2 の戻り値
+    expect(result).toBe(finalState)
+  })
+
+  it('context が全エフェクトに同一オブジェクトとして渡される', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+    const services = makeServices()
+    const context = makeContext()
+
+    const mockEffect1: Effect = { apply: vi.fn((s) => s) }
+    const mockEffect2: Effect = { apply: vi.fn((s) => s) }
+
+    executeEffects([mockEffect1, mockEffect2], state, context, services)
+
+    expect(mockEffect1.apply).toHaveBeenCalledWith(expect.anything(), context, services)
+    expect(mockEffect2.apply).toHaveBeenCalledWith(expect.anything(), context, services)
+  })
+
+  it('services が全エフェクトに同一オブジェクトとして渡される', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+    const services = makeServices()
+    const context = makeContext()
+
+    const mockEffect1: Effect = { apply: vi.fn((s) => s) }
+    const mockEffect2: Effect = { apply: vi.fn((s) => s) }
+
+    executeEffects([mockEffect1, mockEffect2], state, context, services)
+
+    expect(mockEffect1.apply).toHaveBeenCalledWith(expect.anything(), context, services)
+    expect(mockEffect2.apply).toHaveBeenCalledWith(expect.anything(), context, services)
+  })
+})
+
+// ─────────────────────────────────────────────
+// executeEffects — AC3: 不正なエフェクトデータでシステムがクラッシュしない
+// ─────────────────────────────────────────────
+
+describe('executeEffects - AC3: エフェクトリストが空でもクラッシュしない', () => {
+  it('空のエフェクト配列でクラッシュしない', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+
+    expect(() => executeEffects([], state, makeContext(), makeServices())).not.toThrow()
+  })
+
+  it('空配列のとき戻り値は入力 state と等しい', () => {
+    const player = makePlayer()
+    const state = makeBattleState(player)
+
+    const result = executeEffects([], state, makeContext(), makeServices())
+
+    expect(result).toStrictEqual(state)
+  })
+})

--- a/tests/application/effects/EffectFactory.test.ts
+++ b/tests/application/effects/EffectFactory.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { EffectFactory } from '../../../src/application/effects/EffectFactory'
+import { DamageEffect } from '../../../src/application/effects/DamageEffect'
+import { BlockEffect } from '../../../src/application/effects/BlockEffect'
+import { DrawEffect } from '../../../src/application/effects/DrawEffect'
+import { type EffectDef } from '../../../src/shared/types'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEffectDef(overrides: Partial<EffectDef> & { type: string; value: number }): EffectDef {
+  return {
+    type: overrides.type,
+    value: overrides.value,
+    target: overrides.target,
+  }
+}
+
+// ─────────────────────────────────────────────
+// EffectFactory — 基本動作 (AC5, 観点26)
+// ─────────────────────────────────────────────
+
+describe('EffectFactory - 基本動作', () => {
+  it('空の EffectDef[] から ok([]) が返る', () => {
+    const result = EffectFactory.build([])
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toHaveLength(0)
+  })
+
+  it('単一の damage EffectDef から DamageEffect が生成される', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'damage', value: 6 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toHaveLength(1)
+      expect(result.value[0]).toBeInstanceOf(DamageEffect)
+    }
+  })
+
+  it('単一の block EffectDef から BlockEffect が生成される', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'block', value: 5 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toHaveLength(1)
+      expect(result.value[0]).toBeInstanceOf(BlockEffect)
+    }
+  })
+
+  it('単一の draw EffectDef から DrawEffect が生成される', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'draw', value: 2 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toHaveLength(1)
+      expect(result.value[0]).toBeInstanceOf(DrawEffect)
+    }
+  })
+})
+
+// ─────────────────────────────────────────────
+// EffectFactory — 複数エフェクト (AC2)
+// ─────────────────────────────────────────────
+
+describe('EffectFactory - 複数エフェクト', () => {
+  it('複数の EffectDef から複数の Effect が正しい順序で生成される', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'damage', value: 8 }),
+      makeEffectDef({ type: 'block', value: 5 }),
+    ]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toHaveLength(2)
+      expect(result.value[0]).toBeInstanceOf(DamageEffect)
+      expect(result.value[1]).toBeInstanceOf(BlockEffect)
+    }
+  })
+
+  it('damage + draw の EffectDef から対応するエフェクトが順番通りに生成される', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'damage', value: 6 }),
+      makeEffectDef({ type: 'draw', value: 1 }),
+    ]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toHaveLength(2)
+      expect(result.value[0]).toBeInstanceOf(DamageEffect)
+      expect(result.value[1]).toBeInstanceOf(DrawEffect)
+    }
+  })
+
+  it('3つの EffectDef から3つの Effect が生成される', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'damage', value: 5 }),
+      makeEffectDef({ type: 'block', value: 3 }),
+      makeEffectDef({ type: 'draw', value: 1 }),
+    ]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toHaveLength(3)
+  })
+})
+
+// ─────────────────────────────────────────────
+// EffectFactory — 未知のエフェクトタイプはエラーを返す (AC3, 観点27)
+// ─────────────────────────────────────────────
+
+describe('EffectFactory - 未知のエフェクトタイプ（AC3: err を返す）', () => {
+  it('未知のタイプのみの場合は err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'unknown_effect', value: 10 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toHaveLength(1)
+      expect(result.error[0]).toContain('unknown_effect')
+    }
+  })
+
+  it('未知のタイプが混在するとき err を返す（エラーに未知タイプの情報が含まれる）', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'damage', value: 6 }),
+      makeEffectDef({ type: 'unknown_effect', value: 99 }),
+      makeEffectDef({ type: 'block', value: 5 }),
+    ]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error[0]).toContain('unknown_effect')
+  })
+
+  it('全て未知のタイプのとき err を返す（エラー数が def 数と一致）', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'fire', value: 10 }),
+      makeEffectDef({ type: 'ice', value: 5 }),
+    ]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toHaveLength(2)
+  })
+
+  it('空文字タイプは err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: '', value: 5 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────
+// EffectFactory — 不正なデータでシステムがクラッシュしない (AC3)
+// ─────────────────────────────────────────────
+
+describe('EffectFactory - 不正データ耐性（AC3: err を返す）', () => {
+  it('value が負の damage def は err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'damage', value: -5 })]
+
+    expect(() => EffectFactory.build(defs)).not.toThrow()
+    const result = EffectFactory.build(defs)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error[0]).toContain('damage')
+  })
+
+  it('value が負の block def は err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'block', value: -3 })]
+
+    expect(() => EffectFactory.build(defs)).not.toThrow()
+    const result = EffectFactory.build(defs)
+    expect(result.ok).toBe(false)
+  })
+
+  it('value が NaN の def は err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'damage', value: NaN })]
+
+    expect(() => EffectFactory.build(defs)).not.toThrow()
+    const result = EffectFactory.build(defs)
+    expect(result.ok).toBe(false)
+  })
+
+  it('value が Infinity の def は err を返す', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'damage', value: Infinity })]
+
+    expect(() => EffectFactory.build(defs)).not.toThrow()
+    const result = EffectFactory.build(defs)
+    expect(result.ok).toBe(false)
+  })
+
+  it('不正な def が混在しても throw しない。有効な def があっても err を返す', () => {
+    const defs: EffectDef[] = [
+      makeEffectDef({ type: 'damage', value: -1 }), // 不正
+      makeEffectDef({ type: 'block', value: 5 }),    // 有効
+    ]
+
+    expect(() => EffectFactory.build(defs)).not.toThrow()
+    const result = EffectFactory.build(defs)
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────
+// EffectFactory — EffectDef の value が正しく渡される
+// ─────────────────────────────────────────────
+
+describe('EffectFactory - EffectDef の value がエフェクトに反映される', () => {
+  it('draw def の value=3 から DrawEffect(3) が生成される（間接確認）', () => {
+    const defs: EffectDef[] = [makeEffectDef({ type: 'draw', value: 3 })]
+    const result = EffectFactory.build(defs)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value[0]).toBeInstanceOf(DrawEffect)
+  })
+})

--- a/tests/domain/rules/CombatRules.test.ts
+++ b/tests/domain/rules/CombatRules.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { applyDamageToCharacter } from '../../../src/domain/rules/CombatRules'
+import { type Combatant } from '../../../src/domain/entities/Character'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeCombatant(hp: number, blockValue: number): Combatant {
+  const health = Health.create(hp, hp)
+  const block = Block.create(blockValue)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+  return { health: health.value, block: block.value, powers: [], statusEffects: [] }
+}
+
+// ─────────────────────────────────────────────
+// applyDamageToCharacter — ブロックなし
+// ─────────────────────────────────────────────
+
+describe('applyDamageToCharacter - ブロックなし', () => {
+  it('ブロック0のとき全ダメージがHPに適用される', () => {
+    const combatant = makeCombatant(50, 0)
+    const result = applyDamageToCharacter(combatant, 10)
+    expect(result.health.current).toBe(40)
+    expect(result.block.value).toBe(0)
+  })
+
+  it('ダメージ0のときHPとブロックは変わらない', () => {
+    const combatant = makeCombatant(50, 0)
+    const result = applyDamageToCharacter(combatant, 0)
+    expect(result.health.current).toBe(50)
+    expect(result.block.value).toBe(0)
+  })
+
+  it('HPを超えるダメージでもHP は0以下にならない', () => {
+    const combatant = makeCombatant(10, 0)
+    const result = applyDamageToCharacter(combatant, 100)
+    expect(result.health.current).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────
+// applyDamageToCharacter — ブロック先行消費ルール
+// ─────────────────────────────────────────────
+
+describe('applyDamageToCharacter - ブロック先行消費ルール', () => {
+  it('ブロックがダメージより大きいとき HPは減らずブロックだけ減る', () => {
+    const combatant = makeCombatant(50, 20)
+    const result = applyDamageToCharacter(combatant, 10)
+    expect(result.health.current).toBe(50)
+    expect(result.block.value).toBe(10)
+  })
+
+  it('ブロックがダメージより小さいとき残りダメージがHPに適用される', () => {
+    const combatant = makeCombatant(50, 5)
+    const result = applyDamageToCharacter(combatant, 10)
+    expect(result.health.current).toBe(45)
+    expect(result.block.value).toBe(0)
+  })
+
+  it('ブロックとダメージが等しいとき HPは減らずブロックは0になる', () => {
+    const combatant = makeCombatant(50, 10)
+    const result = applyDamageToCharacter(combatant, 10)
+    expect(result.health.current).toBe(50)
+    expect(result.block.value).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────
+// applyDamageToCharacter — イミュータビリティ・型保持
+// ─────────────────────────────────────────────
+
+describe('applyDamageToCharacter - イミュータビリティ', () => {
+  it('元のcombatantを変更しない', () => {
+    const combatant = makeCombatant(50, 10)
+    const originalHp = combatant.health.current
+    applyDamageToCharacter(combatant, 10)
+    expect(combatant.health.current).toBe(originalHp)
+  })
+
+  it('新しいオブジェクトを返す（元の参照とは異なる）', () => {
+    const combatant = makeCombatant(50, 10)
+    const result = applyDamageToCharacter(combatant, 10)
+    expect(result).not.toBe(combatant)
+  })
+
+  it('ジェネリクスにより拡張フィールドが保持される', () => {
+    const extended = { ...makeCombatant(50, 0), id: 'test_id', name: 'Test' }
+    const result = applyDamageToCharacter(extended, 10)
+    expect(result.id).toBe('test_id')
+    expect(result.name).toBe('Test')
+  })
+})

--- a/tests/domain/rules/EnemyRules.test.ts
+++ b/tests/domain/rules/EnemyRules.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { updateEnemy } from '../../../src/domain/rules/EnemyRules'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type EnemyId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemy(id: string, hp = 50, blockValue = 0): Enemy {
+  const health = Health.create(hp, hp)
+  const block = Block.create(blockValue)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: id as EnemyId,
+    intent: { type: 'unknown' },
+    health: health.value,
+    block: block.value,
+    powers: [],
+    statusEffects: [],
+  }
+}
+
+// ─────────────────────────────────────────────
+// updateEnemy — 正常系
+// ─────────────────────────────────────────────
+
+describe('updateEnemy - 正常系', () => {
+  it('指定 id の敵のみが updater によって更新される', () => {
+    const enemy = makeEnemy('jaw_worm', 50)
+    const enemies = [enemy]
+
+    const result = updateEnemy(enemies, 'jaw_worm', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value[0]?.health.current).toBe(40)
+  })
+
+  it('複数の敵がいる場合、対象の敵のみが更新される', () => {
+    const target = makeEnemy('jaw_worm', 50)
+    const other = makeEnemy('louse', 30)
+    const enemies = [target, other]
+
+    const result = updateEnemy(enemies, 'jaw_worm', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value[0]?.health.current).toBe(40) // jaw_worm 更新済み
+      expect(result.value[1]?.health.current).toBe(30) // louse 変化なし
+    }
+  })
+
+  it('空の enemies 配列を渡すと enemy_not_found を返す', () => {
+    const result = updateEnemy([], 'jaw_worm', (e) => e)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('enemy_not_found')
+  })
+})
+
+// ─────────────────────────────────────────────
+// updateEnemy — 対象なし
+// ─────────────────────────────────────────────
+
+describe('updateEnemy - 対象なし（Result error）', () => {
+  it('対象 id が存在しない場合は enemy_not_found を返す', () => {
+    const enemy = makeEnemy('jaw_worm', 50)
+    const enemies = [enemy]
+
+    const result = updateEnemy(enemies, 'non_existent', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('enemy_not_found')
+  })
+
+  it('対象なし時、元の敵には影響がない', () => {
+    const enemy = makeEnemy('jaw_worm', 50)
+    const originalHp = enemy.health.current
+
+    updateEnemy([enemy], 'non_existent', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(enemy.health.current).toBe(originalHp)
+  })
+})
+
+// ─────────────────────────────────────────────
+// updateEnemy — イミュータビリティ
+// ─────────────────────────────────────────────
+
+describe('updateEnemy - イミュータビリティ', () => {
+  it('元の enemies 配列を変更しない', () => {
+    const enemy = makeEnemy('jaw_worm', 50)
+    const enemies = [enemy]
+    const originalHp = enemy.health.current
+
+    updateEnemy(enemies, 'jaw_worm', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(enemy.health.current).toBe(originalHp)
+    expect(enemies[0]?.health.current).toBe(originalHp)
+  })
+
+  it('新しい配列を返す（元の参照とは異なる）', () => {
+    const enemies = [makeEnemy('jaw_worm', 50)]
+
+    const result = updateEnemy(enemies, 'jaw_worm', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).not.toBe(enemies)
+  })
+
+  it('対象でない敵オブジェクトの参照は変わらない', () => {
+    const target = makeEnemy('jaw_worm', 50)
+    const other = makeEnemy('louse', 30)
+    const enemies = [target, other]
+
+    const result = updateEnemy(enemies, 'jaw_worm', (e) => ({
+      ...e,
+      health: e.health.takeDamage(10),
+    }))
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value[1]).toBe(other) // louse は同一参照
+  })
+})


### PR DESCRIPTION
## Summary

- `Effect` インターフェースと `SingleTargetEffect` / `AllEnemiesEffect` / `SelfEffect` サブタイプを実装
- `EffectFactory.build()` で `EffectDef[] → Result<Effect[], string[]>` に変換
- `executeEffects()` で Effect[] を順次 BattleState に適用するパイプライン関数を実装
- アーキテクトレビュー対応として Clean Architecture の依存方向・責務分離を徹底

## 受け入れ条件チェックリスト

- [x] AC1: カードをプレイするとエフェクトが順番に実行される
- [x] AC2: 複数エフェクトを持つカードで全エフェクトが実行される
- [x] AC3: 不正なエフェクトデータでシステムがクラッシュしない（Result 型でエラーを伝播）
- [x] AC4: 依存方向ルールに違反しない（domain ← application 遵守）
- [x] AC5: カードの JSON エフェクト定義から対応する実行可能なエフェクトが生成される

## アーキテクト指摘対応

| 問題 | 対応内容 |
|------|---------|
| BattleState が application 層 | `domain/entities/BattleState.ts` に移動 |
| DamageEffect の Target 決め打ち | `SingleTargetEffect` / `AllEnemiesEffect` / `SelfEffect` サブタイプ設計 |
| EffectContext 分離 | `target` を `BattleState` から除去し `EffectContext` として分離 |
| EffectFactory サイレント失敗 | `Result<Effect[], string[]>` 返却 |
| updateEnemy silent no-op | `Result<readonly Enemy[], 'enemy_not_found'>` 返却 |
| ダメージ計算が application 層 | `CombatRules.applyDamageToCharacter()` を domain に抽出 |
| BlockEffect 非対称 | `PlayerRules.setPlayerBlock()` を domain に追加 |
| EffectExecutor クラス化不要 | `executeEffects` 純粋関数に変更 |
| DrawCardEffect 命名不統一 | `DrawEffect` にリネーム |

## Test plan

- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run test:run` PASS（26 suites / 515 tests）
- [x] DamageEffect / BlockEffect / DrawEffect / EffectFactory / EffectExecutor のテストあり
- [x] CombatRules / EnemyRules / PlayerRules のドメインルールテストあり

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)