### PR TITLE
feat: T138 ダメージ計算がブロック・状態効果を考慮して正確に行われる

### DIFF
--- a/src/application/effects/AllEnemiesDamageEffect.ts
+++ b/src/application/effects/AllEnemiesDamageEffect.ts
@@ -1,0 +1,40 @@
+import {
+  type AllEnemiesEffect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from './Effect'
+import { applyDamageToCharacter, calculateDamage } from '../../domain/rules/CombatRules'
+
+/**
+ * 全体ダメージエフェクト（アプリケーション層）
+ *
+ * カードをプレイしたときに全ての敵にダメージを与える（AllEnemiesEffect）。
+ * 各敵に対して個別にダメージ計算（calculateDamage）とブロック吸収（applyDamageToCharacter）を行う。
+ *
+ * - context.target.kind === 'all' を前提とする
+ * - 各敵の Vulnerable は個別に評価される
+ * - 攻撃者（プレイヤー）の Strength / Weak は全敵に共通適用される
+ * - 参照可能な層: domain, application/effects のみ
+ * - 参照してはいけない層: infrastructure, presentation
+ */
+export class AllEnemiesDamageEffect implements AllEnemiesEffect {
+  readonly targetKind = 'all' as const
+
+  constructor(private readonly amount: number) {
+    if (!Number.isInteger(amount) || amount < 0) {
+      throw new Error(
+        `AllEnemiesDamageEffect: amount must be a non-negative integer, got ${amount}`,
+      )
+    }
+  }
+
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
+    void context // AllEnemiesEffect: 全敵対象のためターゲット指定不要
+    void services // このエフェクトでは未使用
+    const updatedEnemies = state.enemies.map((enemy) =>
+      applyDamageToCharacter(enemy, calculateDamage(this.amount, state.player, enemy)),
+    )
+    return { ...state, enemies: updatedEnemies }
+  }
+}

--- a/src/application/effects/BlockEffect.ts
+++ b/src/application/effects/BlockEffect.ts
@@ -5,6 +5,7 @@ import {
   type EffectServices,
 } from './Effect'
 import { setPlayerBlock } from '../../domain/rules/PlayerRules'
+import { calculateBlock } from '../../domain/rules/CombatRules'
 
 /**
  * ブロックエフェクト（アプリケーション層）
@@ -30,7 +31,7 @@ export class BlockEffect implements SelfEffect {
   apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
     void context // SelfEffect: プレイヤー自身に適用するためターゲット不要
     void services // SelfEffect インターフェース互換のため省略不可（このエフェクトでは未使用）
-    const updatedBlock = state.player.block.add(this.amount)
+    const updatedBlock = state.player.block.add(calculateBlock(this.amount, state.player))
     return { ...state, player: setPlayerBlock(state.player, updatedBlock) }
   }
 }

--- a/src/application/effects/DamageEffect.ts
+++ b/src/application/effects/DamageEffect.ts
@@ -5,7 +5,7 @@ import {
   type EffectServices,
 } from './Effect'
 import { updateEnemy } from '../../domain/rules/EnemyRules'
-import { applyDamageToCharacter } from '../../domain/rules/CombatRules'
+import { applyDamageToCharacter, calculateDamage } from '../../domain/rules/CombatRules'
 
 /**
  * ダメージエフェクト（アプリケーション層）
@@ -38,7 +38,7 @@ export class DamageEffect implements SingleTargetEffect {
     }
 
     const result = updateEnemy(state.enemies, target.id, (enemy) =>
-      applyDamageToCharacter(enemy, this.amount),
+      applyDamageToCharacter(enemy, calculateDamage(this.amount, state.player, enemy)),
     )
     // 対象敵が既に存在しない場合（先に倒れた等）は state をそのまま返す
     const updatedEnemies = result.ok ? result.value : state.enemies

--- a/src/application/effects/EffectFactory.ts
+++ b/src/application/effects/EffectFactory.ts
@@ -3,6 +3,7 @@ import { type Effect } from './Effect'
 import { DamageEffect } from './DamageEffect'
 import { BlockEffect } from './BlockEffect'
 import { DrawEffect } from './DrawEffect'
+import { AllEnemiesDamageEffect } from './AllEnemiesDamageEffect'
 
 type EffectBuilder = (def: EffectDef) => Effect
 
@@ -16,6 +17,7 @@ const EFFECT_BUILDERS: Record<string, EffectBuilder> = {
   damage: (def) => new DamageEffect(def.value),
   block: (def) => new BlockEffect(def.value),
   draw: (def) => new DrawEffect(def.value),
+  all_enemies_damage: (def) => new AllEnemiesDamageEffect(def.value),
 }
 
 /**
@@ -25,7 +27,7 @@ const EFFECT_BUILDERS: Record<string, EffectBuilder> = {
  *
  * - 成功時: ok(Effect[]) を返す
  * - 未知タイプ・不正値があった場合: err(errors) を返す（エラー内容を文字列配列で通知）
- * - Error 以外の予期しない例外は再スローしてプログラマーバグを隠さない
+ * - コンストラクタの例外は全て err に変換する（不正な EffectDef データを安全に処理するため）
  * - 参照可能な層: domain, application/effects のみ
  * - 参照してはいけない層: infrastructure, presentation
  */
@@ -43,8 +45,9 @@ export class EffectFactory {
       try {
         effects.push(builder(def))
       } catch (e) {
-        if (!(e instanceof Error)) throw e
-        errors.push(`Failed to build effect "${def.type}": ${e.message}`)
+        errors.push(
+          `Failed to build effect "${def.type}": ${e instanceof Error ? e.message : String(e)}`,
+        )
       }
     }
 

--- a/src/domain/entities/StatusEffect.ts
+++ b/src/domain/entities/StatusEffect.ts
@@ -4,6 +4,7 @@ import { type StatusEffectId } from '../../shared/types'
  * 状態効果種別
  *
  * - strength    : 筋力（攻撃力増加、スタック型）
+ * - dexterity   : 俊敏（ブロック量増加、スタック型）
  * - artifact    : アーティファクト（デバフ無効化、スタック型）
  * - vulnerable  : 脆弱（被ダメージ増加、持続ターン型）
  * - weak        : 縛り（攻撃力減少、持続ターン型）
@@ -12,6 +13,7 @@ import { type StatusEffectId } from '../../shared/types'
  */
 export const StatusEffectType = {
   Strength: 'Strength',
+  Dexterity: 'Dexterity',
   Artifact: 'Artifact',
   Vulnerable: 'Vulnerable',
   Weak: 'Weak',
@@ -24,20 +26,35 @@ export type StatusEffectType = (typeof StatusEffectType)[keyof typeof StatusEffe
 /**
  * スタック型状態効果（stacks が意味を持ち、duration は使わない）
  */
-export const StackingStatusEffectTypes: readonly StatusEffectType[] = [
+export const StackingStatusEffectTypes = [
   StatusEffectType.Strength,
+  StatusEffectType.Dexterity,
   StatusEffectType.Artifact,
   StatusEffectType.Poison,
   StatusEffectType.Burn,
-] as const
+] as const satisfies readonly StatusEffectType[]
 
 /**
  * 持続ターン型状態効果（duration が意味を持ち、stacks は使わない）
  */
-export const DurationStatusEffectTypes: readonly StatusEffectType[] = [
+export const DurationStatusEffectTypes = [
   StatusEffectType.Vulnerable,
   StatusEffectType.Weak,
-] as const
+] as const satisfies readonly StatusEffectType[]
+
+/**
+ * compile-time 網羅性チェック
+ *
+ * 新しい StatusEffectType を追加して StackingStatusEffectTypes か
+ * DurationStatusEffectTypes への追加を忘れた場合、この行がコンパイルエラーになる。
+ */
+type _UncoveredStatusEffectType = Exclude<
+  StatusEffectType,
+  (typeof StackingStatusEffectTypes)[number] | (typeof DurationStatusEffectTypes)[number]
+>
+const _statusEffectExhaustiveCheck: [_UncoveredStatusEffectType] extends [never] ? true : never =
+  true
+void _statusEffectExhaustiveCheck
 
 /**
  * 状態効果エンティティ

--- a/src/domain/rules/CombatRules.ts
+++ b/src/domain/rules/CombatRules.ts
@@ -1,4 +1,67 @@
 import { type Combatant } from '../entities/Character'
+import { StatusEffectType } from '../entities/StatusEffect'
+
+/**
+ * 攻撃者・対象の状態効果を考慮してダメージ量を計算する（純粋関数）。
+ *
+ * 適用順:
+ *   1. base + strength(stacks)
+ *   2. floor(×0.75) if attacker has Weak (duration > 0)
+ *   3. floor(×1.5)  if target has Vulnerable (duration > 0)
+ *
+ * @param baseAmount - カードのベースダメージ（非負整数）
+ * @param attacker   - 攻撃するキャラクター
+ * @param target     - ダメージを受けるキャラクター
+ * @returns 最終ダメージ量（0以上）
+ *
+ * 参照可能な層: domain/entities のみ
+ */
+export function calculateDamage(
+  baseAmount: number,
+  attacker: Combatant,
+  target: Combatant,
+): number {
+  if (!Number.isFinite(baseAmount) || baseAmount < 0) {
+    throw new Error(
+      `calculateDamage: baseAmount must be a non-negative finite number, got ${baseAmount}`,
+    )
+  }
+
+  const strength =
+    attacker.statusEffects.find((se) => se.type === StatusEffectType.Strength)?.stacks ?? 0
+  const isWeak =
+    (attacker.statusEffects.find((se) => se.type === StatusEffectType.Weak)?.duration ?? 0) > 0
+  const isVulnerable =
+    (target.statusEffects.find((se) => se.type === StatusEffectType.Vulnerable)?.duration ?? 0) > 0
+
+  let damage = baseAmount + strength
+  if (isWeak) damage = Math.floor(damage * 0.75)
+  if (isVulnerable) damage = Math.floor(damage * 1.5)
+  return Math.max(0, damage)
+}
+
+/**
+ * 防御者の状態効果を考慮してブロック獲得量を計算する（純粋関数）。
+ *
+ * 適用: base + dexterity(stacks)
+ *
+ * @param baseAmount - カードのベースブロック量（非負整数）
+ * @param defender   - ブロックを得るキャラクター
+ * @returns 最終ブロック量（0以上）
+ *
+ * 参照可能な層: domain/entities のみ
+ */
+export function calculateBlock(baseAmount: number, defender: Combatant): number {
+  if (!Number.isFinite(baseAmount) || baseAmount < 0) {
+    throw new Error(
+      `calculateBlock: baseAmount must be a non-negative finite number, got ${baseAmount}`,
+    )
+  }
+
+  const dexterity =
+    defender.statusEffects.find((se) => se.type === StatusEffectType.Dexterity)?.stacks ?? 0
+  return Math.max(0, baseAmount + dexterity)
+}
 
 /**
  * キャラクターにダメージを適用した新しいインスタンスを返す（純粋関数）。

--- a/src/presentation/viewmodels/useBattleViewModel.ts
+++ b/src/presentation/viewmodels/useBattleViewModel.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { castDraft } from 'immer'
+import { type Player } from '../../domain/entities/Player'
+import { type Enemy } from '../../domain/entities/Enemy'
+import { type Card } from '../../domain/entities/Card'
+import { type IRandomService } from '../../domain/interfaces/IRandomService'
+import { type Target } from '../../shared/types'
+import { EffectFactory } from '../../application/effects/EffectFactory'
+import { executeEffects } from '../../application/effects/EffectExecutor'
+import { type BattleState } from '../../domain/entities/BattleState'
+
+/**
+ * 戦闘データの discriminated union
+ *
+ * - idle:   戦闘未開始
+ * - active: 戦闘進行中。player・enemies・randomService が確定している
+ * - error:  エフェクト構築失敗（不正なカードデータ等）。reason にエラー詳細が入る
+ */
+export type BattleData =
+  | { readonly status: 'idle' }
+  | {
+      readonly status: 'active'
+      readonly player: Player
+      readonly enemies: readonly Enemy[]
+      readonly randomService: IRandomService
+    }
+  | { readonly status: 'error'; readonly reason: readonly string[] }
+
+/**
+ * 戦闘ViewModel — 戦闘状態を管理する Zustand ストア
+ *
+ * 責務:
+ * - 戦闘の初期化（initBattle）
+ * - カードプレイ（playCard）による状態更新
+ * - battleData を UI に公開
+ *
+ * アーキテクチャ:
+ * - Immer ミドルウェアで draft 変更（presentation 層のみ許容）
+ * - EffectFactory + EffectExecutor を通じてエフェクト実行
+ * - RandomService は initBattle 時に外部から注入（テスト可能性を確保）
+ * - RandomService は BattleData の active 状態に含め、モジュールレベルの変数を排除
+ *
+ * 参照可能な層: domain, application, infrastructure（RandomService）
+ */
+interface BattleViewModelState {
+  readonly battleData: BattleData
+  readonly initBattle: (
+    player: Player,
+    enemies: readonly Enemy[],
+    randomService: IRandomService,
+  ) => void
+  readonly playCard: (card: Card, target: Target | undefined) => void
+}
+
+export const useBattleViewModel = create<BattleViewModelState>()(
+  immer((set, get) => ({
+    battleData: { status: 'idle' },
+
+    initBattle: (player, enemies, randomService) => {
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player,
+          enemies,
+          randomService,
+        })
+      })
+    },
+
+    playCard: (card, target) => {
+      const { battleData } = get()
+      if (battleData.status !== 'active') return
+
+      const effectsResult = EffectFactory.build(card.effects)
+      if (!effectsResult.ok) {
+        set((draft) => {
+          draft.battleData = castDraft({
+            status: 'error' as const,
+            reason: effectsResult.error,
+          })
+        })
+        return
+      }
+
+      const currentState: BattleState = {
+        player: battleData.player,
+        enemies: battleData.enemies,
+      }
+      const context = { target }
+      const services = { random: battleData.randomService }
+
+      const nextState = executeEffects(effectsResult.value, currentState, context, services)
+
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player: nextState.player,
+          enemies: nextState.enemies,
+          randomService: battleData.randomService,
+        })
+      })
+    },
+  })),
+)

--- a/tests/application/effects/AllEnemiesDamageEffect.test.ts
+++ b/tests/application/effects/AllEnemiesDamageEffect.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi } from 'vitest'
+import { AllEnemiesDamageEffect } from '../../../src/application/effects/AllEnemiesDamageEffect'
+import {
+  type Effect,
+  type BattleState,
+  type EffectContext,
+  type EffectServices,
+} from '../../../src/application/effects/Effect'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type StatusEffectId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+  }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makePlayer(statusEffects: StatusEffect[] = []): Player {
+  const health = Health.create(80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects,
+  }
+}
+
+function makeServices(): EffectServices {
+  return {
+    random: {
+      next: vi.fn(() => 0),
+      nextInt: vi.fn((min: number) => min),
+      shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+        ...array,
+      ]) as IRandomService['shuffle'],
+    },
+  }
+}
+
+function makeBattleState(enemies: readonly Enemy[], player?: Player): BattleState {
+  return {
+    player: player ?? makePlayer(),
+    enemies,
+  }
+}
+
+function makeAllContext(): EffectContext {
+  return { target: { kind: 'all' } }
+}
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect — インターフェース適合
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect - Effect インターフェース適合', () => {
+  it('Effect インターフェースを実装している', () => {
+    const effect: Effect = new AllEnemiesDamageEffect(10)
+    expect(effect).toBeDefined()
+  })
+
+  it('正の整数値で構築できる', () => {
+    const effect = new AllEnemiesDamageEffect(10)
+    expect(effect).toBeInstanceOf(AllEnemiesDamageEffect)
+  })
+
+  it('targetKind が "all" である', () => {
+    const effect = new AllEnemiesDamageEffect(10)
+    expect(effect.targetKind).toBe('all')
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect — 生成・コンストラクタ
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect - 生成', () => {
+  it('観点02: value=0 で正常に生成できる（境界値：最小正常値）', () => {
+    expect(() => new AllEnemiesDamageEffect(0)).not.toThrow()
+  })
+
+  it('観点01: value=1 で正常に生成できる', () => {
+    expect(() => new AllEnemiesDamageEffect(1)).not.toThrow()
+  })
+
+  it('観点01: value が負のとき生成時にエラーを投げる（下限違反）', () => {
+    expect(() => new AllEnemiesDamageEffect(-1)).toThrow()
+  })
+
+  it('観点07: value が NaN のとき生成時にエラーを投げる', () => {
+    expect(() => new AllEnemiesDamageEffect(NaN)).toThrow()
+  })
+
+  it('観点07: value が Infinity のとき生成時にエラーを投げる', () => {
+    expect(() => new AllEnemiesDamageEffect(Infinity)).toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — AC7: 全体攻撃
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - AC7: 全体攻撃', () => {
+  it('観点01: 敵が1体のとき、その敵のHPが減る', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const state = makeBattleState([enemy])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(40)
+  })
+
+  it('観点01: 敵が2体のとき、全ての敵のHPが減る', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 0 })
+    const state = makeBattleState([enemy1, enemy2])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    const resultEnemy1 = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    const resultEnemy2 = result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))
+    expect(resultEnemy1?.health.current).toBe(40)
+    expect(resultEnemy2?.health.current).toBe(20)
+  })
+
+  it('観点01: 敵が3体のとき、全ての敵のHPが減る', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 0 })
+    const enemy3 = makeEnemy('fungi_beast', { currentHp: 40, maxHp: 40, block: 0 })
+    const state = makeBattleState([enemy1, enemy2, enemy3])
+    const effect = new AllEnemiesDamageEffect(8)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current).toBe(42)
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))?.health.current).toBe(22)
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('fungi_beast'))?.health.current).toBe(32)
+  })
+
+  it('観点02: 敵が0体のとき state をそのまま返す（境界値：空配列）', () => {
+    const state = makeBattleState([])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.enemies).toHaveLength(0)
+    expect(result.enemies).toStrictEqual(state.enemies)
+  })
+
+  it('観点02: value=0 のとき全ての敵のHPが変わらない（境界値）', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30 })
+    const state = makeBattleState([enemy1, enemy2])
+    const effect = new AllEnemiesDamageEffect(0)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current).toBe(50)
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))?.health.current).toBe(30)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — AC7: ブロック吸収
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - AC7: ブロック吸収（全体攻撃）', () => {
+  it('観点01: 各敵のブロックが先に消費されてから HP に適用される', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 5 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 15 })
+    const state = makeBattleState([enemy1, enemy2])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    const resultEnemy1 = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    const resultEnemy2 = result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))
+    // enemy1: block=5 absorbed, 10-5=5 damage to hp → 45
+    expect(resultEnemy1?.health.current).toBe(45)
+    expect(resultEnemy1?.block.value).toBe(0)
+    // enemy2: block=15 > damage=10, hp unchanged, block=5
+    expect(resultEnemy2?.health.current).toBe(30)
+    expect(resultEnemy2?.block.value).toBe(5)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — AC7: 状態効果（Vulnerable）
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - AC7: 脆弱な敵への全体攻撃', () => {
+  it('観点16: Vulnerable な敵と通常の敵が混在するとき各自の倍率が適用される', () => {
+    const normalEnemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const vulnerableEnemy = makeEnemy('louse', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    const state = makeBattleState([normalEnemy, vulnerableEnemy])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    const resultNormal = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    const resultVulnerable = result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))
+    // normalEnemy: 50 - 10 = 40
+    expect(resultNormal?.health.current).toBe(40)
+    // vulnerableEnemy: 50 - floor(10 * 1.5) = 50 - 15 = 35
+    expect(resultVulnerable?.health.current).toBe(35)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — AC7: Weak（攻撃者）
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - AC7: 弱体化プレイヤーの全体攻撃', () => {
+  it('観点01: プレイヤーが Weak(duration=1) のとき全ての敵に ×0.75 floor ダメージを与える', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 0 })
+    const player = makePlayer([makeStatusEffect(StatusEffectType.Weak, 0, 1)])
+    const state = makeBattleState([enemy1, enemy2], player)
+    // base=10, floor(10 * 0.75) = 7
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current).toBe(43)
+    expect(result.enemies.find((e) => e.enemyId === makeEnemyId('louse'))?.health.current).toBe(23)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — イミュータビリティ
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - イミュータビリティ（観点11）', () => {
+  it('apply は元の BattleState を変更しない', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30 })
+    const state = makeBattleState([enemy1, enemy2])
+    const originalHp1 = state.enemies[0]?.health.current
+    const originalHp2 = state.enemies[1]?.health.current
+    const effect = new AllEnemiesDamageEffect(10)
+
+    effect.apply(state, makeAllContext(), makeServices())
+
+    expect(state.enemies[0]?.health.current).toBe(originalHp1)
+    expect(state.enemies[1]?.health.current).toBe(originalHp2)
+  })
+
+  it('apply は元の Enemy オブジェクトを変更せず新しいオブジェクトを返す', () => {
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30 })
+    const state = makeBattleState([enemy1, enemy2])
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.enemies[0]).not.toBe(state.enemies[0])
+    expect(result.enemies[1]).not.toBe(state.enemies[1])
+  })
+
+  it('apply は player を変更しない', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const player = makePlayer()
+    const state = makeBattleState([enemy], player)
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const result = effect.apply(state, makeAllContext(), makeServices())
+
+    expect(result.player).toBe(state.player)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AllEnemiesDamageEffect.apply — 冪等性
+// ─────────────────────────────────────────────
+
+describe('AllEnemiesDamageEffect.apply - 冪等性（観点28）', () => {
+  it('同一の BattleState で複数回呼んでも毎回同じ結果になる', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const effect = new AllEnemiesDamageEffect(10)
+
+    const state1 = makeBattleState([makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })])
+    const state2 = makeBattleState([makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })])
+    const result1 = effect.apply(state1, makeAllContext(), makeServices())
+    const result2 = effect.apply(state2, makeAllContext(), makeServices())
+
+    void enemy // suppress unused warning
+    expect(result1.enemies[0]?.health.current).toBe(result2.enemies[0]?.health.current)
+  })
+})

--- a/tests/application/effects/BlockEffect.test.ts
+++ b/tests/application/effects/BlockEffect.test.ts
@@ -8,8 +8,9 @@ import {
 } from '../../../src/application/effects/Effect'
 import { type Player } from '../../../src/domain/entities/Player'
 import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
 import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
-import { type EnemyId } from '../../../src/shared/types'
+import { type EnemyId, type StatusEffectId } from '../../../src/shared/types'
 import { Health } from '../../../src/domain/value-objects/Health'
 import { Block } from '../../../src/domain/value-objects/Block'
 import { Energy } from '../../../src/domain/value-objects/Energy'
@@ -21,6 +22,16 @@ import { Gold } from '../../../src/domain/value-objects/Gold'
 
 function makeEnemyId(id: string): EnemyId {
   return id as EnemyId
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
 }
 
 function makeEnemy(id: string): Enemy {
@@ -39,6 +50,11 @@ function makeEnemy(id: string): Enemy {
     powers: [],
     statusEffects: [],
   }
+}
+
+function makePlayerWithStatusEffects(statusEffects: StatusEffect[]): Player {
+  const player = makePlayer()
+  return { ...player, statusEffects }
 }
 
 function makePlayer(
@@ -265,5 +281,101 @@ describe('BlockEffect.apply - BattleState への反映', () => {
     const result = effect.apply(state, makeContext(), makeServices())
 
     expect(result).not.toBe(state)
+  })
+})
+
+// ─────────────────────────────────────────────
+// BlockEffect.apply — AC6: 俊敏（Dexterity）バフ/デバフ
+// ─────────────────────────────────────────────
+
+describe('BlockEffect.apply - AC6: 俊敏（Dexterity）バフ/デバフ', () => {
+  it('観点01: プレイヤーが Dexterity(stacks=2) のとき base+2 ブロックを獲得する', () => {
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Dexterity, 2, 0)])
+    const state = makeBattleState(player)
+    // base=5, +2 dexterity → block=7
+    const effect = new BlockEffect(5)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(7)
+  })
+
+  it('観点01: プレイヤーが Dexterity(stacks=-3) のとき base-3 ブロックを獲得する（デバフ）', () => {
+    const player = makePlayerWithStatusEffects([
+      makeStatusEffect(StatusEffectType.Dexterity, -3, 0),
+    ])
+    const state = makeBattleState(player)
+    // base=5, -3 dexterity → block=2
+    const effect = new BlockEffect(5)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(2)
+  })
+
+  it('観点02: Dexterity(stacks=0) のとき変化なし（境界値）', () => {
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Dexterity, 0, 0)])
+    const state = makeBattleState(player)
+    const effect = new BlockEffect(5)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(5)
+  })
+
+  it('観点01: Dexterity デバフで結果が 0 未満にならない（最小値 0 保証）', () => {
+    const player = makePlayerWithStatusEffects([
+      makeStatusEffect(StatusEffectType.Dexterity, -10, 0),
+    ])
+    const state = makeBattleState(player)
+    // base=3, -10 dexterity → max(0, 3-10) = 0
+    const effect = new BlockEffect(3)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(0)
+  })
+
+  it('観点04: Dexterity(stacks=5) かつ 既存ブロック(3) の組み合わせ（中間値）', () => {
+    const player = makePlayer({ block: 3 })
+    const playerWithDex = {
+      ...player,
+      statusEffects: [makeStatusEffect(StatusEffectType.Dexterity, 5, 0)],
+    }
+    const state = makeBattleState(playerWithDex)
+    // base=4, +5 dexterity → 9, existing block 3 → total 12
+    const effect = new BlockEffect(4)
+
+    const result = effect.apply(state, makeContext(), makeServices())
+
+    expect(result.player.block.value).toBe(12)
+  })
+
+  it('観点11: 元の player Combatant を変更しない（イミュータビリティ）', () => {
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Dexterity, 2, 0)])
+    const state = makeBattleState(player)
+    const originalBlock = state.player.block.value
+    const originalStacks = state.player.statusEffects[0]?.stacks
+    const effect = new BlockEffect(5)
+
+    effect.apply(state, makeContext(), makeServices())
+
+    expect(state.player.block.value).toBe(originalBlock)
+    expect(state.player.statusEffects[0]?.stacks).toBe(originalStacks)
+  })
+
+  it('観点28: 同一 Dexterity 状態で複数回呼んでも同じブロック増加量（冪等性）', () => {
+    const player1 = makePlayerWithStatusEffects([
+      makeStatusEffect(StatusEffectType.Dexterity, 3, 0),
+    ])
+    const player2 = makePlayerWithStatusEffects([
+      makeStatusEffect(StatusEffectType.Dexterity, 3, 0),
+    ])
+    const effect = new BlockEffect(5)
+
+    const result1 = effect.apply(makeBattleState(player1), makeContext(), makeServices())
+    const result2 = effect.apply(makeBattleState(player2), makeContext(), makeServices())
+
+    expect(result1.player.block.value).toBe(result2.player.block.value)
   })
 })

--- a/tests/application/effects/DamageEffect.test.ts
+++ b/tests/application/effects/DamageEffect.test.ts
@@ -8,8 +8,9 @@ import {
 } from '../../../src/application/effects/Effect'
 import { type Player } from '../../../src/domain/entities/Player'
 import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
 import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
-import { type EnemyId, type Target } from '../../../src/shared/types'
+import { type EnemyId, type Target, type StatusEffectId } from '../../../src/shared/types'
 import { Health } from '../../../src/domain/value-objects/Health'
 import { Block } from '../../../src/domain/value-objects/Block'
 import { Energy } from '../../../src/domain/value-objects/Energy'
@@ -23,9 +24,24 @@ function makeEnemyId(id: string): EnemyId {
   return id as EnemyId
 }
 
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
 function makeEnemy(
   id: string,
-  overrides?: Partial<{ currentHp: number; maxHp: number; block: number }>,
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+  }>,
 ): Enemy {
   const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
   const block = Block.create(overrides?.block ?? 0)
@@ -40,8 +56,13 @@ function makeEnemy(
     health: hp.value,
     block: block.value,
     powers: [],
-    statusEffects: [],
+    statusEffects: overrides?.statusEffects ?? [],
   }
+}
+
+function makePlayerWithStatusEffects(statusEffects: StatusEffect[]): Player {
+  const player = makePlayer()
+  return { ...player, statusEffects }
 }
 
 function makePlayer(): Player {
@@ -320,5 +341,192 @@ describe('DamageEffect.apply - イミュータビリティ', () => {
     const result = effect.apply(state, makeContext(target), makeServices())
 
     expect(result.player).toBe(state.player)
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — AC2: 筋力バフ/デバフ（Strength）
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - AC2: 筋力バフ/デバフ（Strength）', () => {
+  it('観点01: プレイヤーが Strength(stacks=3) のとき敵に base+3 ダメージを与える', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Strength, 3, 0)])
+    const state = makeBattleState([enemy], player)
+    // base=6, +3 strength → damage=9
+    const effect = new DamageEffect(6)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(41)
+  })
+
+  it('観点01: プレイヤーが Strength(stacks=-2) のとき敵に base-2 ダメージを与える（デバフ）', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Strength, -2, 0)])
+    const state = makeBattleState([enemy], player)
+    // base=6, -2 strength → damage=4
+    const effect = new DamageEffect(6)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(46)
+  })
+
+  it('観点28: 同一 Strength 状態で複数回呼んでも同じダメージ（冪等性）', () => {
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Strength, 3, 0)])
+    const effect = new DamageEffect(6)
+
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const state1 = makeBattleState([enemy1], player)
+    const result1 = effect.apply(state1, makeContext(target), makeServices())
+
+    const enemy2 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    const state2 = makeBattleState([enemy2], player)
+    const result2 = effect.apply(state2, makeContext(target), makeServices())
+
+    const hp1 = result1.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current
+    const hp2 = result2.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current
+    expect(hp1).toBe(hp2)
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — AC3: 脆弱（Vulnerable）
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - AC3: 脆弱（Vulnerable）', () => {
+  it('観点01: 敵が Vulnerable(duration=1) のとき ×1.5 floor ダメージを受ける', () => {
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const state = makeBattleState([enemy])
+    // base=10, floor(10 * 1.5) = 15
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(35)
+  })
+
+  it('観点01: floor 切り捨てが適用される（5 * 1.5 = 7.5 → 7）', () => {
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)],
+    })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(5)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(43)
+  })
+
+  it('観点02: 敵が Vulnerable(duration=0) のとき倍率なし（境界値）', () => {
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 0)],
+    })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const state = makeBattleState([enemy])
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(40)
+  })
+
+  it('観点16: Vulnerable あり vs なし で受けるダメージに差がある', () => {
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const effect = new DamageEffect(10)
+
+    const normalEnemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const normalState = makeBattleState([normalEnemy])
+    const normalResult = effect.apply(normalState, makeContext(target), makeServices())
+
+    const vulnerableEnemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    const vulnerableState = makeBattleState([vulnerableEnemy])
+    const vulnerableResult = effect.apply(vulnerableState, makeContext(target), makeServices())
+
+    const normalHp = normalResult.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health
+      .current
+    const vulnerableHp = vulnerableResult.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+      ?.health.current
+
+    expect(vulnerableHp).toBeLessThan(normalHp!)
+  })
+})
+
+// ─────────────────────────────────────────────
+// DamageEffect.apply — AC5: 弱体化（Weak）
+// ─────────────────────────────────────────────
+
+describe('DamageEffect.apply - AC5: 弱体化（Weak）', () => {
+  it('観点01: プレイヤーが Weak(duration=1) のとき ×0.75 floor ダメージを与える', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Weak, 0, 1)])
+    const state = makeBattleState([enemy], player)
+    // base=10, floor(10 * 0.75) = 7
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(43)
+  })
+
+  it('観点02: プレイヤーが Weak(duration=0) のとき倍率なし（境界値）', () => {
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Weak, 0, 0)])
+    const state = makeBattleState([enemy], player)
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(40)
+  })
+
+  it('観点16: Weak(attacker) かつ Vulnerable(target) の組み合わせテスト', () => {
+    // base=10, weak floor(10*0.75)=7, vulnerable floor(7*1.5)=10
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    const player = makePlayerWithStatusEffects([makeStatusEffect(StatusEffectType.Weak, 0, 1)])
+    const state = makeBattleState([enemy], player)
+    const effect = new DamageEffect(10)
+
+    const result = effect.apply(state, makeContext(target), makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(40)
   })
 })

--- a/tests/domain/rules/CombatRules.test.ts
+++ b/tests/domain/rules/CombatRules.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { applyDamageToCharacter } from '../../../src/domain/rules/CombatRules'
+import {
+  applyDamageToCharacter,
+  calculateDamage,
+  calculateBlock,
+} from '../../../src/domain/rules/CombatRules'
 import { type Combatant } from '../../../src/domain/entities/Character'
+import { type StatusEffect } from '../../../src/domain/entities/StatusEffect'
+import { StatusEffectType } from '../../../src/domain/entities/StatusEffect'
 import { Health } from '../../../src/domain/value-objects/Health'
 import { Block } from '../../../src/domain/value-objects/Block'
+import { type StatusEffectId } from '../../../src/shared/types'
 
 // ─────────────────────────────────────────────
 // Test helpers
@@ -14,6 +21,25 @@ function makeCombatant(hp: number, blockValue: number): Combatant {
   if (!health.ok) throw new Error('Failed to create health')
   if (!block.ok) throw new Error('Failed to create block')
   return { health: health.value, block: block.value, powers: [], statusEffects: [] }
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeCombatantWithStatusEffects(
+  hp: number,
+  blockValue: number,
+  statusEffects: StatusEffect[],
+): Combatant {
+  const base = makeCombatant(hp, blockValue)
+  return { ...base, statusEffects }
 }
 
 // ─────────────────────────────────────────────
@@ -92,5 +118,307 @@ describe('applyDamageToCharacter - イミュータビリティ', () => {
     const result = applyDamageToCharacter(extended, 10)
     expect(result.id).toBe('test_id')
     expect(result.name).toBe('Test')
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — 正常系・同値クラス (AC2/AC3/AC5)
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - 正常系（状態効果なし）', () => {
+  it('観点01: 状態効果なしのとき baseAmount をそのまま返す', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(10, attacker, target)).toBe(10)
+  })
+
+  it('観点02: baseAmount=0 のとき結果は 0 になる（境界値：最小正常値）', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(0, attacker, target)).toBe(0)
+  })
+
+  it('観点04: baseAmount=6 のとき同値クラス中間値で期待値を返す', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(6, attacker, target)).toBe(6)
+  })
+
+  it('観点28: 同一入力で複数回呼んでも同じ結果になる（冪等性）', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    const result1 = calculateDamage(10, attacker, target)
+    const result2 = calculateDamage(10, attacker, target)
+    expect(result1).toBe(result2)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — AC2: 筋力バフ/デバフ
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - AC2: 筋力バフ/デバフ（Strength）', () => {
+  it('観点01: 正のStrength(stacks=3)のとき base+3 になる', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, 3, 0),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(6, attacker, target)).toBe(9)
+  })
+
+  it('観点01: 負のStrength(stacks=-2)のとき base-2 になる（デバフ）', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, -2, 0),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(6, attacker, target)).toBe(4)
+  })
+
+  it('観点02: Strength(stacks=0)のとき変化なし（境界値）', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, 0, 0),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(6, attacker, target)).toBe(6)
+  })
+
+  it('観点11: 元の attacker Combatant を変更しない（イミュータビリティ）', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, 5, 0),
+    ])
+    const target = makeCombatant(50, 0)
+    const originalStacks = attacker.statusEffects[0]?.stacks
+    calculateDamage(6, attacker, target)
+    expect(attacker.statusEffects[0]?.stacks).toBe(originalStacks)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — AC3: 脆弱（Vulnerable）
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - AC3: 脆弱（Vulnerable）', () => {
+  it('観点01: target が Vulnerable(duration=1) のとき ×1.5 floor になる', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 1),
+    ])
+    // floor(10 * 1.5) = 15
+    expect(calculateDamage(10, attacker, target)).toBe(15)
+  })
+
+  it('観点01: floor 切り捨てが適用される（5 * 1.5 = 7.5 → 7）', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 2),
+    ])
+    expect(calculateDamage(5, attacker, target)).toBe(7)
+  })
+
+  it('観点02: target が Vulnerable(duration=0) のとき倍率なし', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 0),
+    ])
+    expect(calculateDamage(10, attacker, target)).toBe(10)
+  })
+
+  it('観点16: Vulnerable なし vs あり の組み合わせで差異が出る', () => {
+    const attacker = makeCombatant(80, 0)
+    const normalTarget = makeCombatant(50, 0)
+    const vulnerableTarget = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 1),
+    ])
+    const dmgNormal = calculateDamage(10, attacker, normalTarget)
+    const dmgVulnerable = calculateDamage(10, attacker, vulnerableTarget)
+    expect(dmgVulnerable).toBeGreaterThan(dmgNormal)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — AC5: 弱体化（Weak）
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - AC5: 弱体化（Weak）', () => {
+  it('観点01: attacker が Weak(duration=1) のとき ×0.75 floor になる', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Weak, 0, 1),
+    ])
+    const target = makeCombatant(50, 0)
+    // floor(10 * 0.75) = 7
+    expect(calculateDamage(10, attacker, target)).toBe(7)
+  })
+
+  it('観点01: floor 切り捨てが適用される（6 * 0.75 = 4.5 → 4）', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Weak, 0, 2),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(6, attacker, target)).toBe(4)
+  })
+
+  it('観点02: attacker が Weak(duration=0) のとき倍率なし', () => {
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Weak, 0, 0),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(10, attacker, target)).toBe(10)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — AC2+AC3+AC5: 複合条件（決定表）
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - 複合条件（決定表）', () => {
+  it('観点16: Strength+3 かつ Vulnerable(target) のとき正しく計算される', () => {
+    // base=10, +3 strength → 13, vulnerable ×1.5 floor → floor(13 * 1.5) = 19
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, 3, 0),
+    ])
+    const target = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 1),
+    ])
+    expect(calculateDamage(10, attacker, target)).toBe(19)
+  })
+
+  it('観点16: Weak(attacker) かつ Vulnerable(target) のとき正しく計算される', () => {
+    // base=10, weak ×0.75 floor → 7, vulnerable ×1.5 floor → floor(7 * 1.5) = 10
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Weak, 0, 1),
+    ])
+    const target = makeCombatantWithStatusEffects(50, 0, [
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 1),
+    ])
+    expect(calculateDamage(10, attacker, target)).toBe(10)
+  })
+
+  it('観点16: Strength+3 かつ Weak(attacker) のとき正しく計算される', () => {
+    // base=10, +3 strength → 13, weak ×0.75 floor → floor(13 * 0.75) = 9
+    const attacker = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Strength, 3, 0),
+      makeStatusEffect(StatusEffectType.Weak, 0, 1),
+    ])
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(10, attacker, target)).toBe(9)
+  })
+
+  it('観点16: 全効果なしのとき baseAmount をそのまま返す', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(calculateDamage(10, attacker, target)).toBe(10)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateDamage — 特殊数値（NaN / Infinity）
+// ─────────────────────────────────────────────
+
+describe('calculateDamage - 特殊数値（観点07）', () => {
+  it('baseAmount が NaN のときエラーを投げる', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(() => calculateDamage(NaN, attacker, target)).toThrow()
+  })
+
+  it('baseAmount が Infinity のときエラーまたはフォールバック値を返す', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(() => calculateDamage(Infinity, attacker, target)).toThrow()
+  })
+
+  it('baseAmount が負の数のときエラーを投げる（観点05）', () => {
+    const attacker = makeCombatant(80, 0)
+    const target = makeCombatant(50, 0)
+    expect(() => calculateDamage(-1, attacker, target)).toThrow(
+      /calculateDamage: baseAmount must be a non-negative finite number/,
+    )
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateBlock — 正常系（AC6）
+// ─────────────────────────────────────────────
+
+describe('calculateBlock - 正常系（状態効果なし）', () => {
+  it('観点01: 状態効果なしのとき baseAmount をそのまま返す', () => {
+    const defender = makeCombatant(80, 0)
+    expect(calculateBlock(5, defender)).toBe(5)
+  })
+
+  it('観点02: baseAmount=0 のとき結果は 0 になる（境界値：最小正常値）', () => {
+    const defender = makeCombatant(80, 0)
+    expect(calculateBlock(0, defender)).toBe(0)
+  })
+
+  it('観点28: 同一入力で複数回呼んでも同じ結果になる（冪等性）', () => {
+    const defender = makeCombatant(80, 0)
+    expect(calculateBlock(5, defender)).toBe(calculateBlock(5, defender))
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateBlock — AC6: 俊敏（Dexterity）
+// ─────────────────────────────────────────────
+
+describe('calculateBlock - AC6: 俊敏（Dexterity）', () => {
+  it('観点01: 正の Dexterity(stacks=2) のとき base+2 になる', () => {
+    const defender = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Dexterity, 2, 0),
+    ])
+    expect(calculateBlock(5, defender)).toBe(7)
+  })
+
+  it('観点01: 負の Dexterity(stacks=-3) のとき base-3 になる（デバフ）', () => {
+    const defender = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Dexterity, -3, 0),
+    ])
+    expect(calculateBlock(5, defender)).toBe(2)
+  })
+
+  it('観点02: Dexterity(stacks=0) のとき変化なし（境界値）', () => {
+    const defender = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Dexterity, 0, 0),
+    ])
+    expect(calculateBlock(5, defender)).toBe(5)
+  })
+
+  it('観点01: Dexterity デバフで結果が 0 未満にならない（最小値 0 保証）', () => {
+    const defender = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Dexterity, -10, 0),
+    ])
+    expect(calculateBlock(3, defender)).toBe(0)
+  })
+
+  it('観点11: 元の defender Combatant を変更しない（イミュータビリティ）', () => {
+    const defender = makeCombatantWithStatusEffects(80, 0, [
+      makeStatusEffect(StatusEffectType.Dexterity, 2, 0),
+    ])
+    const originalStacks = defender.statusEffects[0]?.stacks
+    calculateBlock(5, defender)
+    expect(defender.statusEffects[0]?.stacks).toBe(originalStacks)
+  })
+})
+
+// ─────────────────────────────────────────────
+// calculateBlock — 特殊数値（NaN / Infinity）
+// ─────────────────────────────────────────────
+
+describe('calculateBlock - 特殊数値（観点07）', () => {
+  it('baseAmount が NaN のときエラーまたはフォールバック値を返す', () => {
+    const defender = makeCombatant(80, 0)
+    expect(() => calculateBlock(NaN, defender)).toThrow()
+  })
+
+  it('baseAmount が Infinity のときエラーまたはフォールバック値を返す', () => {
+    const defender = makeCombatant(80, 0)
+    expect(() => calculateBlock(Infinity, defender)).toThrow()
+  })
+
+  it('baseAmount が負の数のときエラーを投げる（観点05）', () => {
+    const defender = makeCombatant(80, 0)
+    expect(() => calculateBlock(-1, defender)).toThrow(
+      /calculateBlock: baseAmount must be a non-negative finite number/,
+    )
   })
 })

--- a/tests/presentation/viewmodels/useBattleViewModel.test.ts
+++ b/tests/presentation/viewmodels/useBattleViewModel.test.ts
@@ -1,0 +1,538 @@
+/**
+ * useBattleViewModel テスト（AC4: ダメージ計算結果が UI の HP 表示に反映される）
+ *
+ * useBattleViewModel は未実装のため、このテストは現時点で RED（失敗）になる。
+ * 実装時は Zustand + Immer を使用し、initBattle / playCard アクションを提供すること。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useBattleViewModel } from '../../../src/presentation/viewmodels/useBattleViewModel'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type Card } from '../../../src/domain/entities/Card'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type Target, type StatusEffectId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+  }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makePlayer(
+  overrides?: Partial<{ currentHp: number; block: number; statusEffects: StatusEffect[] }>,
+): Player {
+  const health = Health.create(overrides?.currentHp ?? 80, 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makeRandomService(): IRandomService {
+  return {
+    next: vi.fn(() => 0),
+    nextInt: vi.fn((min: number) => min),
+    shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+      ...array,
+    ]) as IRandomService['shuffle'],
+  }
+}
+
+/** ダメージカード（単体攻撃）のスタブ */
+function makeDamageCard(amount: number): Card {
+  return {
+    id: `strike_${amount}`,
+    name: 'Strike',
+    cost: 1,
+    description: `Deal ${amount} damage.`,
+    effects: [{ type: 'damage', value: amount }],
+    keywords: [],
+  } as unknown as Card
+}
+
+/** ブロックカード（プレイヤー自身）のスタブ */
+function makeBlockCard(amount: number): Card {
+  return {
+    id: `defend_${amount}`,
+    name: 'Defend',
+    cost: 1,
+    description: `Gain ${amount} block.`,
+    effects: [{ type: 'block', value: amount }],
+    keywords: [],
+  } as unknown as Card
+}
+
+/** 全体攻撃カードのスタブ */
+function makeAllEnemiesCard(amount: number): Card {
+  return {
+    id: `cleave_${amount}`,
+    name: 'Cleave',
+    cost: 1,
+    description: `Deal ${amount} damage to ALL enemies.`,
+    effects: [{ type: 'all_enemies_damage', value: amount }],
+    keywords: [],
+  } as unknown as Card
+}
+
+// ─────────────────────────────────────────────
+// Setup
+// ─────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // ストアをリセット
+  useBattleViewModel.setState({
+    battleData: { status: 'idle' },
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — 初期状態
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - 初期状態', () => {
+  it('battleData.status が "idle" である', () => {
+    const { battleData } = useBattleViewModel.getState()
+    expect(battleData.status).toBe('idle')
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — initBattle アクション
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - initBattle', () => {
+  it('観点01: initBattle を呼ぶと battleData.status が "active" になる', () => {
+    const player = makePlayer()
+    const enemies = [makeEnemy('jaw_worm')]
+    useBattleViewModel.getState().initBattle(player, enemies, makeRandomService())
+
+    const { battleData } = useBattleViewModel.getState()
+    expect(battleData.status).toBe('active')
+  })
+
+  it('観点01: initBattle 後に player の HP が UI に反映される', () => {
+    const player = makePlayer({ currentHp: 72 })
+    const enemies = [makeEnemy('jaw_worm', { currentHp: 42 })]
+    useBattleViewModel.getState().initBattle(player, enemies, makeRandomService())
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.health.current).toBe(72)
+  })
+
+  it('観点01: initBattle 後に enemies の HP が UI に反映される', () => {
+    const player = makePlayer()
+    const enemies = [makeEnemy('jaw_worm', { currentHp: 42, maxHp: 50 })]
+    useBattleViewModel.getState().initBattle(player, enemies, makeRandomService())
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const enemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(enemy?.health.current).toBe(42)
+  })
+
+  it('観点11: initBattle は引数の player/enemies オブジェクトを変更しない（イミュータビリティ）', () => {
+    const player = makePlayer({ currentHp: 80 })
+    const enemies = [makeEnemy('jaw_worm', { currentHp: 50 })]
+    const originalPlayerHp = player.health.current
+    const originalEnemyHp = enemies[0]?.health.current
+
+    useBattleViewModel.getState().initBattle(player, enemies, makeRandomService())
+
+    expect(player.health.current).toBe(originalPlayerHp)
+    expect(enemies[0]?.health.current).toBe(originalEnemyHp)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC1 ブロック軽減
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC1 ブロック軽減', () => {
+  it('観点01: ブロックがある敵にダメージカードをプレイするとブロック分が軽減される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 5 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    // damage=10, block=5 → HP は 50 - (10-5) = 45
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(45)
+    expect(resultEnemy?.block.value).toBe(0)
+  })
+
+  it('観点04: ブロック > ダメージ のとき HP は変わらずブロックだけ減る（中間値）', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 20 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(50)
+    expect(resultEnemy?.block.value).toBe(10)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC2 筋力バフ/デバフ
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC2 筋力バフ/デバフ', () => {
+  it('観点01: プレイヤーが Strength(stacks=3) のとき UI に正しいダメージ後 HP が反映される', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Strength, 3, 0)],
+    })
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    // base=6, +3 strength → damage=9
+    const card = makeDamageCard(6)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(41)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC3 脆弱（Vulnerable）
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC3 脆弱（Vulnerable）', () => {
+  it('観点01: Vulnerable な敵への攻撃ダメージが 1.5倍（floor）になり UI に反映される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 50,
+      maxHp: 50,
+      block: 0,
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    // base=10, floor(10 * 1.5) = 15
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(35)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC4 HP 表示への反映
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC4 HP 表示への反映', () => {
+  it('観点01: ダメージカードをプレイするたびに battleData.enemies の HP が更新される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const card = makeDamageCard(6)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const state1 = useBattleViewModel.getState()
+    if (state1.battleData.status !== 'active') throw new Error('expected active')
+    expect(
+      state1.battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current,
+    ).toBe(44)
+
+    useBattleViewModel.getState().playCard(card, target)
+
+    const state2 = useBattleViewModel.getState()
+    if (state2.battleData.status !== 'active') throw new Error('expected active')
+    expect(
+      state2.battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current,
+    ).toBe(38)
+  })
+
+  it('観点01: ブロックカードをプレイすると battleData.player のブロックが更新される', () => {
+    const player = makePlayer({ block: 0 })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const card = makeBlockCard(5)
+    useBattleViewModel.getState().playCard(card, { kind: 'player' })
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.block.value).toBe(5)
+  })
+
+  it('観点11: playCard は元の BattleState に相当するデータを変更しない（イミュータビリティ）', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const stateBeforePlay = useBattleViewModel.getState()
+    if (stateBeforePlay.battleData.status !== 'active') throw new Error('expected active')
+    const originalEnemy = stateBeforePlay.battleData.enemies.find(
+      (e) => e.enemyId === makeEnemyId('jaw_worm'),
+    )
+    const originalHp = originalEnemy?.health.current
+
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    // 旧スナップショットの enemy は変更されていない
+    expect(originalEnemy?.health.current).toBe(originalHp)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC5 弱体化（Weak）
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC5 弱体化（Weak）', () => {
+  it('観点01: Weak なプレイヤーがダメージカードをプレイすると 25%減のダメージが UI に反映される', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Weak, 0, 1)],
+    })
+    const enemy = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    // base=10, floor(10 * 0.75) = 7
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(card, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    expect(resultEnemy?.health.current).toBe(43)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC6 俊敏（Dexterity）
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC6 俊敏（Dexterity）', () => {
+  it('観点01: Dexterity(stacks=2) なプレイヤーがブロックカードをプレイすると base+2 のブロックが UI に反映される', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Dexterity, 2, 0)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    // base=5, +2 dexterity → block=7
+    const card = makeBlockCard(5)
+    useBattleViewModel.getState().playCard(card, { kind: 'player' })
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.block.value).toBe(7)
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — playCard: AC7 全体攻撃
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - playCard: AC7 全体攻撃', () => {
+  it('観点01: 全体攻撃カードをプレイすると全ての敵のHPが UI に反映される', () => {
+    const player = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy1, enemy2], makeRandomService())
+
+    const card = makeAllEnemiesCard(8)
+    useBattleViewModel.getState().playCard(card, { kind: 'all' })
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(
+      battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current,
+    ).toBe(42)
+    expect(battleData.enemies.find((e) => e.enemyId === makeEnemyId('louse'))?.health.current).toBe(
+      22,
+    )
+  })
+
+  it('観点04: 全体攻撃で各敵のブロックが個別に消費される（中間値）', () => {
+    const player = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 3 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 15 })
+    useBattleViewModel.getState().initBattle(player, [enemy1, enemy2], makeRandomService())
+
+    // damage=10: enemy1 block=3→0, hp 50-7=43; enemy2 block=15>10, hp unchanged block=5
+    const card = makeAllEnemiesCard(10)
+    useBattleViewModel.getState().playCard(card, { kind: 'all' })
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy1 = battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))
+    const resultEnemy2 = battleData.enemies.find((e) => e.enemyId === makeEnemyId('louse'))
+    expect(resultEnemy1?.health.current).toBe(43)
+    expect(resultEnemy1?.block.value).toBe(0)
+    expect(resultEnemy2?.health.current).toBe(30)
+    expect(resultEnemy2?.block.value).toBe(5)
+  })
+
+  it('観点02: 全体攻撃 value=0 のとき全ての敵のHP・ブロックは変わらない（境界値）', () => {
+    const player = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 5 })
+    const enemy2 = makeEnemy('louse', { currentHp: 30, maxHp: 30, block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy1, enemy2], makeRandomService())
+
+    const card = makeAllEnemiesCard(0)
+    useBattleViewModel.getState().playCard(card, { kind: 'all' })
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(
+      battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health.current,
+    ).toBe(50)
+    expect(battleData.enemies.find((e) => e.enemyId === makeEnemyId('louse'))?.health.current).toBe(
+      30,
+    )
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — エラー状態（観点33）
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - エラー状態（#3: EffectFactory 失敗時）', () => {
+  it('未知のエフェクトタイプを持つカードをプレイすると battleData.status が "error" になる', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const badCard = {
+      id: 'bad_card',
+      name: 'Bad',
+      cost: 1,
+      description: '',
+      effects: [{ type: 'unknown_effect', value: 10 }],
+      keywords: [],
+    } as unknown as import('../../../src/domain/entities/Card').Card
+
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+    useBattleViewModel.getState().playCard(badCard, target)
+
+    const { battleData } = useBattleViewModel.getState()
+    expect(battleData.status).toBe('error')
+    if (battleData.status === 'error') {
+      expect(battleData.reason.length).toBeGreaterThan(0)
+      expect(battleData.reason[0]).toContain('unknown_effect')
+    }
+  })
+})
+
+// ─────────────────────────────────────────────
+// useBattleViewModel — 冪等性（観点28）
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - 冪等性（観点28）', () => {
+  it('同じ初期状態から同じカードをプレイすると毎回同じ結果になる', () => {
+    const card = makeDamageCard(10)
+    const target: Target = { kind: 'enemy', id: makeEnemyId('jaw_worm') }
+
+    // 1回目
+    const player1 = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    useBattleViewModel.getState().initBattle(player1, [enemy1], makeRandomService())
+    useBattleViewModel.getState().playCard(card, target)
+    const state1 = useBattleViewModel.getState()
+    if (state1.battleData.status !== 'active') throw new Error('expected active')
+    const hp1 = state1.battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health
+      .current
+
+    // 2回目（リセット後）
+    useBattleViewModel.setState({ battleData: { status: 'idle' } })
+    const player2 = makePlayer()
+    const enemy2 = makeEnemy('jaw_worm', { currentHp: 50, maxHp: 50, block: 0 })
+    useBattleViewModel.getState().initBattle(player2, [enemy2], makeRandomService())
+    useBattleViewModel.getState().playCard(card, target)
+    const state2 = useBattleViewModel.getState()
+    if (state2.battleData.status !== 'active') throw new Error('expected active')
+    const hp2 = state2.battleData.enemies.find((e) => e.enemyId === makeEnemyId('jaw_worm'))?.health
+      .current
+
+    expect(hp1).toBe(hp2)
+  })
+})


### PR DESCRIPTION
## Summary

- `calculateDamage` / `calculateBlock` ドメイン純粋関数を実装（Strength・Dexterity・Weak・Vulnerable 適用）
- `DamageEffect` / `BlockEffect` に状態効果考慮ロジックを適用
- `AllEnemiesDamageEffect` 全体攻撃エフェクト実装（AC7）
- `useBattleViewModel` Zustand + Immer による戦闘状態管理（AC4）
- コードレビュー指摘（8件）を全て対応:
  - `randomService` を BattleData の active 状態に含め、モジュール変数を廃止（#1/#2）
  - EffectFactory 失敗時に `error` 状態として公開（#3）
  - `applyDamageToCharacter` JSDoc を関数直前に移動（#4）
  - `StatusEffectType` 配列の compile-time 網羅性チェック追加（#5）
  - EffectFactory の例外 catch を簡略化（デッドコード除去）（#6）
  - `calculateDamage`/`calculateBlock` に負値バリデーション追加（#7）
  - `StatusEffectType` JSDoc に Dexterity を追記（#8）

## Test plan

- [x] AC1: ブロック軽減が正しく動作する
- [x] AC2: 筋力バフ/デバフがダメージに加算・減算される
- [x] AC3: Vulnerable 状態でダメージ1.5倍
- [x] AC4: 計算結果がUIのHP表示に反映される（useBattleViewModel）
- [x] AC5: Weak 状態でダメージ25%減
- [x] AC6: Dexterity バフ/デバフがブロック獲得量に加算・減算される
- [x] AC7: 全体攻撃カードで全敵にダメージ
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm run test:run` 634テスト全パス

Closes #138