### PR TITLE
feat: T139 状態効果（筋力・俊敏・脆弱等）がターンをまたいで正しく機能する

### DIFF
--- a/src/application/effects/ApplyStatusEffectEffect.ts
+++ b/src/application/effects/ApplyStatusEffectEffect.ts
@@ -1,0 +1,55 @@
+import { type Effect, type BattleState, type EffectContext, type EffectServices } from './Effect'
+import { type StatusEffectType } from '../../domain/entities/StatusEffect'
+import { addStatusEffect } from '../../domain/rules/StatusEffectRules'
+import { updateEnemy } from '../../domain/rules/EnemyRules'
+
+/**
+ * 状態効果付与エフェクト（アプリケーション層）
+ *
+ * カードプレイ時に対象（敵またはプレイヤー）に状態効果を付与する。
+ *
+ * - targetKind === 'enemy': context.target.kind === 'enemy' の単体敵を対象とする
+ * - targetKind === 'player': プレイヤー自身を対象とする
+ *
+ * 参照可能な層: domain, application/effects のみ
+ * 参照してはいけない層: infrastructure, presentation
+ */
+export class ApplyStatusEffectEffect implements Effect {
+  constructor(
+    private readonly statusEffectType: StatusEffectType,
+    private readonly amount: number,
+    readonly targetKind: 'enemy' | 'player',
+  ) {
+    if (!Number.isInteger(amount) || amount < 0) {
+      throw new Error(
+        `ApplyStatusEffectEffect: amount must be a non-negative integer, got ${amount}`,
+      )
+    }
+  }
+
+  apply(state: BattleState, context: EffectContext, services: EffectServices): BattleState {
+    void services
+
+    if (this.targetKind === 'player') {
+      const updatedPlayer = addStatusEffect(state.player, this.statusEffectType, this.amount)
+      return { ...state, player: updatedPlayer }
+    }
+
+    // targetKind === 'enemy'
+    const { target } = context
+    if (!target || target.kind !== 'enemy') {
+      throw new Error(
+        `ApplyStatusEffectEffect: context.target must be { kind: 'enemy', id } but got ${JSON.stringify(target)}`,
+      )
+    }
+
+    const result = updateEnemy(state.enemies, target.id, (enemy) =>
+      addStatusEffect(enemy, this.statusEffectType, this.amount),
+    )
+    if (!result.ok) {
+      throw new Error(`ApplyStatusEffectEffect: enemy not found: ${target.id}`)
+    }
+
+    return { ...state, enemies: result.value }
+  }
+}

--- a/src/application/effects/EffectFactory.ts
+++ b/src/application/effects/EffectFactory.ts
@@ -4,8 +4,12 @@ import { DamageEffect } from './DamageEffect'
 import { BlockEffect } from './BlockEffect'
 import { DrawEffect } from './DrawEffect'
 import { AllEnemiesDamageEffect } from './AllEnemiesDamageEffect'
+import { ApplyStatusEffectEffect } from './ApplyStatusEffectEffect'
+import { StatusEffectType } from '../../domain/entities/StatusEffect'
 
 type EffectBuilder = (def: EffectDef) => Effect
+
+const VALID_STATUS_EFFECT_TYPES: ReadonlySet<string> = new Set(Object.values(StatusEffectType))
 
 /**
  * エフェクトビルダーレジストリ
@@ -18,6 +22,18 @@ const EFFECT_BUILDERS: Record<string, EffectBuilder> = {
   block: (def) => new BlockEffect(def.value),
   draw: (def) => new DrawEffect(def.value),
   all_enemies_damage: (def) => new AllEnemiesDamageEffect(def.value),
+  apply_status_effect: (def) => {
+    const seType = def.statusEffectType
+    if (!seType || !VALID_STATUS_EFFECT_TYPES.has(seType)) {
+      throw new Error(`apply_status_effect: unknown statusEffectType "${seType}"`)
+    }
+    if (def.target !== 'player' && def.target !== 'enemy') {
+      throw new Error(
+        `apply_status_effect: target must be 'player' or 'enemy', got "${def.target}"`,
+      )
+    }
+    return new ApplyStatusEffectEffect(seType as StatusEffectType, def.value, def.target)
+  },
 }
 
 /**

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -1,30 +1,19 @@
-import { type PowerId } from '../../shared/types'
 import { type Health } from '../value-objects/Health'
 import { type Block } from '../value-objects/Block'
 import { type StatusEffect } from './StatusEffect'
-
-/**
- * アクティブパワー
- *
- * 戦闘中に付与されているパワー（筋力・アーティファクト等の永続バフ）の状態。
- * id はパワーの種別識別子、stacks は現在のスタック数を表す。
- */
-export type ActivePower = {
-  readonly id: PowerId
-  readonly stacks: number
-}
+import { type Power } from './Power'
 
 /**
  * Combatant インターフェース
  *
  * Player と Enemy の共通操作を抽象化する。
- * Power は Combatant ではなく Player/Enemy 各自が保持する設計。
- * これにより複数プレイヤー対応や敵 Power への拡張が容易になる。
+ * - statusEffects: 受動的な値参照型の効果（Strength/Dexterity/Vulnerable/Weak/Artifact）
+ * - powers: トリガー型の能動的な効果（Poison/Burn 等、Observer パターンで実装）
  */
 export interface Combatant {
   readonly health: Health
   readonly block: Block
-  readonly powers: readonly ActivePower[]
+  readonly powers: readonly Power[]
   readonly statusEffects: readonly StatusEffect[]
 }
 

--- a/src/domain/entities/Power.ts
+++ b/src/domain/entities/Power.ts
@@ -1,0 +1,104 @@
+import { type PowerId } from '../../shared/types'
+import { type GameEvent } from './Relic'
+import { type Health } from '../value-objects/Health'
+import { type Block } from '../value-objects/Block'
+import { type StatusEffect } from './StatusEffect'
+
+/**
+ * Power が操作する戦闘者の最小構造
+ *
+ * BattleState（Player/Enemy）との循環依存を回避するため、
+ * Power が必要とするフィールドのみを定義する最小型。
+ * BattleState は構造的に BattleStateForPower を満たす。
+ */
+export type CombatantForPower = {
+  readonly health: Health
+  readonly block: Block
+  readonly powers: readonly Power[]
+  readonly statusEffects: readonly StatusEffect[]
+}
+
+/**
+ * Power が受け取る戦闘状態の最小構造
+ *
+ * Player/Enemy の追加フィールド（energy, deck 等）は Power の処理には不要のため含まない。
+ * useBattleViewModel では BattleState をそのまま渡せる（構造的部分型）。
+ */
+export type BattleStateForPower = {
+  readonly player: CombatantForPower
+  readonly enemies: readonly (CombatantForPower & { readonly id: string })[]
+}
+
+/**
+ * Power トリガー時のオーナー情報
+ *
+ * Power がプレイヤーに付与されているか、特定の敵に付与されているかを区別する。
+ */
+export type PowerOwner =
+  | { readonly kind: 'player' }
+  | { readonly kind: 'enemy'; readonly id: string }
+
+/**
+ * Power エンティティ（Observer パターン）
+ *
+ * バフ・デバフを問わず、ゲームイベント（ターン開始・終了等）をトリガーとして
+ * 自律的に処理を実行する効果の基底インターフェース。
+ *
+ * Relic と同様の Observer パターンで実装する。Relic との違い:
+ * - Relic はプレイヤーのみが保有し、ランを通じて永続する
+ * - Power はプレイヤーおよび敵の両方が保有し、戦闘中のみ有効
+ *
+ * onTrigger はジェネリック型を使用することで BattleState との循環依存を回避する。
+ * （BattleState → Player → Combatant → Power → BattleState の循環を防ぐ）
+ *
+ * 参照可能な層: domain/entities, domain/value-objects のみ
+ */
+export interface Power {
+  readonly id: PowerId
+  readonly name: string
+  readonly stacks: number
+  readonly triggers: readonly GameEvent['type'][]
+  onTrigger<S extends BattleStateForPower>(event: GameEvent, owner: PowerOwner, state: S): S
+}
+
+/**
+ * プレイヤーの Powers にイベントを通知し、状態変換を順次適用する（純粋関数）。
+ *
+ * triggers に event.type が含まれる Power のみ実行される。
+ * 実行順序は powers 配列の順（付与された順）に従う。
+ *
+ * @param event - 発生したゲームイベント
+ * @param state - 現在の戦闘状態（BattleState を渡せる）
+ * @returns 更新後の戦闘状態
+ */
+export function notifyPlayerPowers<S extends BattleStateForPower>(event: GameEvent, state: S): S {
+  let current: S = state
+  for (const power of state.player.powers) {
+    if (power.triggers.includes(event.type)) {
+      current = power.onTrigger(event, { kind: 'player' }, current)
+    }
+  }
+  return current
+}
+
+/**
+ * 全敵の Powers にイベントを通知し、状態変換を順次適用する（純粋関数）。
+ *
+ * 敵の順序は enemies 配列の順に従う。各敵の powers は付与順に実行される。
+ * 一人の敵の Power 実行後、次の敵の Power は更新済み状態を受け取る。
+ *
+ * @param event - 発生したゲームイベント
+ * @param state - 現在の戦闘状態（BattleState を渡せる）
+ * @returns 更新後の戦闘状態
+ */
+export function notifyEnemyPowers<S extends BattleStateForPower>(event: GameEvent, state: S): S {
+  let current: S = state
+  for (const enemy of state.enemies) {
+    for (const power of enemy.powers) {
+      if (power.triggers.includes(event.type)) {
+        current = power.onTrigger(event, { kind: 'enemy', id: enemy.id }, current)
+      }
+    }
+  }
+  return current
+}

--- a/src/domain/entities/StatusEffect.ts
+++ b/src/domain/entities/StatusEffect.ts
@@ -3,13 +3,14 @@ import { type StatusEffectId } from '../../shared/types'
 /**
  * 状態効果種別
  *
+ * ダメージ計算等から受動的に参照される値のみを定義する。
+ * トリガー型の効果（Poison/Burn 等）は Power（Observer パターン）として別途実装する。
+ *
  * - strength    : 筋力（攻撃力増加、スタック型）
  * - dexterity   : 俊敏（ブロック量増加、スタック型）
  * - artifact    : アーティファクト（デバフ無効化、スタック型）
  * - vulnerable  : 脆弱（被ダメージ増加、持続ターン型）
  * - weak        : 縛り（攻撃力減少、持続ターン型）
- * - poison      : 毒（ターン開始時ダメージ、スタック型）
- * - burn        : 燃焼（ターン終了時ダメージ、スタック型）
  */
 export const StatusEffectType = {
   Strength: 'Strength',
@@ -17,8 +18,6 @@ export const StatusEffectType = {
   Artifact: 'Artifact',
   Vulnerable: 'Vulnerable',
   Weak: 'Weak',
-  Poison: 'Poison',
-  Burn: 'Burn',
 } as const
 
 export type StatusEffectType = (typeof StatusEffectType)[keyof typeof StatusEffectType]
@@ -30,8 +29,6 @@ export const StackingStatusEffectTypes = [
   StatusEffectType.Strength,
   StatusEffectType.Dexterity,
   StatusEffectType.Artifact,
-  StatusEffectType.Poison,
-  StatusEffectType.Burn,
 ] as const satisfies readonly StatusEffectType[]
 
 /**

--- a/src/domain/entities/powers/PoisonPower.ts
+++ b/src/domain/entities/powers/PoisonPower.ts
@@ -1,0 +1,67 @@
+import { type PowerId } from '../../../shared/types'
+import { type GameEvent } from '../Relic'
+import { type Power, type PowerOwner, type BattleStateForPower } from '../Power'
+
+/**
+ * Poison パワー（ドメイン層）
+ *
+ * ターン開始時にスタック数分の直接 HP ダメージを与え、スタック数を1減算する。
+ * スタックが 0 以下になったら powers 配列から除去される。
+ *
+ * 処理順（on_turn_start）:
+ *   1. オーナー（player または 対象 enemy）に stacks 分のダメージ（ブロック無視）
+ *   2. stacks を 1 減算。0 以下になったら powers から除去
+ *
+ * on_turn_end には反応しない。
+ *
+ * 参照可能な層: domain/entities, domain/value-objects のみ
+ */
+export class PoisonPower implements Power {
+  readonly id: PowerId = 'poison' as PowerId
+  readonly name = 'Poison'
+  readonly triggers: readonly GameEvent['type'][] = ['on_turn_start']
+
+  constructor(readonly stacks: number) {}
+
+  onTrigger<S extends BattleStateForPower>(event: GameEvent, owner: PowerOwner, state: S): S {
+    if (owner.kind === 'player') {
+      return this.applyToPlayer(state)
+    }
+    return this.applyToEnemy(state, owner.id)
+  }
+
+  private applyToPlayer<S extends BattleStateForPower>(state: S): S {
+    const newHealth = state.player.health.takeDamage(this.stacks)
+    const newStacks = this.stacks - 1
+    const newPowers: readonly Power[] =
+      newStacks <= 0
+        ? state.player.powers.filter((p) => p.id !== this.id)
+        : state.player.powers.map((p) => (p.id === this.id ? new PoisonPower(newStacks) : p))
+
+    // `as S` is required because TypeScript cannot verify that spreading state and state.player
+    // preserves all extra fields of S (e.g. Player.energy, deck, hand, etc.).
+    // At runtime, the spread IS safe — all fields of S beyond BattleStateForPower are preserved.
+    return {
+      ...state,
+      player: { ...state.player, health: newHealth, powers: newPowers },
+    } as S
+  }
+
+  private applyToEnemy<S extends BattleStateForPower>(state: S, enemyId: string): S {
+    const updatedEnemies = state.enemies.map((enemy) => {
+      if (enemy.id !== enemyId) return enemy
+
+      const newHealth = enemy.health.takeDamage(this.stacks)
+      const newStacks = this.stacks - 1
+      const newPowers: readonly Power[] =
+        newStacks <= 0
+          ? enemy.powers.filter((p) => p.id !== this.id)
+          : enemy.powers.map((p) => (p.id === this.id ? new PoisonPower(newStacks) : p))
+
+      return { ...enemy, health: newHealth, powers: newPowers }
+    })
+
+    // `as S` — same rationale as applyToPlayer: spread preserves all extra fields at runtime.
+    return { ...state, enemies: updatedEnemies } as S
+  }
+}

--- a/src/domain/rules/StatusEffectRules.ts
+++ b/src/domain/rules/StatusEffectRules.ts
@@ -1,0 +1,107 @@
+import { type Combatant } from '../entities/Character'
+import {
+  type StatusEffect,
+  type StatusEffectType,
+  StackingStatusEffectTypes,
+} from '../entities/StatusEffect'
+import { type StatusEffectId } from '../../shared/types'
+
+/**
+ * 状態効果ルール（ドメイン層）
+ *
+ * 受動型状態効果（Strength/Dexterity/Artifact/Vulnerable/Weak）の
+ * スタック・持続ターン管理に関する純粋関数群。
+ *
+ * トリガー型効果（Poison/Burn 等）は Power（Observer パターン）として別途実装する。
+ * 参照可能な層: domain/entities のみ
+ */
+
+const STACKING_TYPE_SET: ReadonlySet<string> = new Set(StackingStatusEffectTypes)
+
+function isStackingType(type: StatusEffectType): boolean {
+  return STACKING_TYPE_SET.has(type)
+}
+
+/**
+ * Combatant に状態効果を付与した新しいオブジェクトを返す（純粋関数）。
+ *
+ * - スタック型（Strength/Dexterity/Artifact）: stacks を加算
+ * - 持続ターン型（Vulnerable/Weak）: duration を加算
+ * - 既存の同種エフェクトが存在する場合は加算、なければ新規追加
+ * - amount は 0 以上の整数を前提とする（負値は効果を持たない）
+ *
+ * @param combatant - 状態効果を付与するキャラクター（イミュータブル）
+ * @param type      - 付与する状態効果の種別
+ * @param amount    - 加算するスタック数または持続ターン数（0 以上）
+ * @returns 更新後の新しい Combatant オブジェクト
+ */
+/**
+ * StatusEffectType 文字列を StatusEffectId に変換する。
+ *
+ * 設計上の不変条件: StatusEffect.id は常に付与時の StatusEffectType 値と一致する。
+ * （addStatusEffect がこの不変条件を維持する唯一の生成経路）
+ *
+ * 注意: StatusEffectId は `string & brand` 型のため、StatusEffectType を直接代入できない。
+ * StatusEffectId を `StatusEffectType & brand` に変更すればキャストが型安全になるが、
+ * shared/types が domain/entities を import することになり CA 違反になるため、現状は型アサーションを使用する。
+ */
+function toStatusEffectId(type: StatusEffectType): StatusEffectId {
+  return type as StatusEffectId
+}
+
+export function addStatusEffect<T extends Combatant>(
+  combatant: T,
+  type: StatusEffectType,
+  amount: number,
+): T {
+  if (amount < 0) {
+    throw new Error(`addStatusEffect: amount must be >= 0, got ${amount}`)
+  }
+
+  const stacking = isStackingType(type)
+  const existing = combatant.statusEffects.find((se) => se.type === type)
+
+  let updatedEffects: readonly StatusEffect[]
+
+  if (existing) {
+    updatedEffects = combatant.statusEffects.map((se) =>
+      se.type === type
+        ? stacking
+          ? { ...se, stacks: se.stacks + amount }
+          : { ...se, duration: se.duration + amount }
+        : se,
+    )
+  } else {
+    if (amount === 0) {
+      // amount=0 かつ既存エフェクトなし → 意味のないゼロエントリを追加しない
+      return combatant
+    }
+    const newEffect: StatusEffect = {
+      id: toStatusEffectId(type),
+      name: type,
+      type,
+      stacks: stacking ? amount : 0,
+      duration: stacking ? 0 : amount,
+    }
+    updatedEffects = [...combatant.statusEffects, newEffect]
+  }
+
+  return { ...combatant, statusEffects: updatedEffects }
+}
+
+/**
+ * Combatant の持続ターン型状態効果を1ターン減算した新しいオブジェクトを返す（純粋関数）。
+ *
+ * - 持続ターン型（Vulnerable/Weak）: duration を1減算し、0以下になったら除去
+ * - スタック型（Strength/Dexterity/Artifact）: 変化しない
+ *
+ * @param combatant - tick 対象のキャラクター（イミュータブル）
+ * @returns 更新後の新しい Combatant オブジェクト
+ */
+export function tickStatusEffects<T extends Combatant>(combatant: T): T {
+  const updatedEffects = combatant.statusEffects
+    .map((se) => (isStackingType(se.type) ? se : { ...se, duration: se.duration - 1 }))
+    .filter((se) => isStackingType(se.type) || se.duration > 0)
+
+  return { ...combatant, statusEffects: updatedEffects }
+}

--- a/src/presentation/react/App.tsx
+++ b/src/presentation/react/App.tsx
@@ -9,6 +9,7 @@ import { useRunMapSync } from '../hooks/useRunMapSync'
 import { TitleScreen } from './screens/TitleScreen'
 import { CharacterSelectScreen } from './screens/CharacterSelectScreen'
 import { MapScreen } from './screens/MapScreen'
+import { BattleScreen } from './screens/BattleScreen'
 
 // ラン開始前の画面種別（useRunViewModel 管理外の UI フロー）
 type PreRunScreen = 'title' | 'characterSelect'
@@ -61,6 +62,7 @@ export function App(): React.JSX.Element {
           <MapScreen />
         </>
       )}
+      {runData.currentScreen === ScreenType.Combat && <BattleScreen />}
     </div>
   )
 }

--- a/src/presentation/react/screens/BattleScreen.tsx
+++ b/src/presentation/react/screens/BattleScreen.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import { useBattleViewModel } from '../../viewmodels/useBattleViewModel'
+
+/**
+ * presentation 層で使用する状態効果の最小ビュー型。
+ * domain/entities/StatusEffect を直接 import せず、必要なフィールドのみを宣言する。
+ */
+type StatusEffectView = {
+  readonly id: string
+  readonly type: string
+  readonly name: string
+  readonly stacks: number
+  readonly duration: number
+}
+
+/**
+ * 状態効果アイコン
+ *
+ * スタック型は stacks、持続ターン型は duration を表示する。
+ */
+function StatusIcon({ effect }: { effect: StatusEffectView }): React.JSX.Element | null {
+  const value = effect.stacks > 0 ? effect.stacks : effect.duration
+  if (value === 0) return null
+  return (
+    <span
+      title={effect.name}
+      style={{
+        display: 'inline-block',
+        padding: '2px 6px',
+        margin: '0 2px',
+        background: '#444',
+        border: '1px solid #aaa',
+        borderRadius: 4,
+        fontSize: 12,
+        color: '#fff',
+      }}
+    >
+      {effect.type}:{value}
+    </span>
+  )
+}
+
+/**
+ * BattleScreen — 戦闘画面（React オーバーレイ）
+ *
+ * useBattleViewModel からプレイヤー・敵の HP / ブロック / 状態効果を読み取り、
+ * ステータスアイコンとして表示する（AC3）。
+ *
+ * 参照可能な層: presentation のみ
+ */
+export function BattleScreen(): React.JSX.Element {
+  const { battleData } = useBattleViewModel()
+
+  if (battleData.status !== 'active') {
+    return (
+      <div style={{ color: '#fff', padding: 16 }}>
+        {battleData.status === 'error'
+          ? `エラー: ${battleData.reason.join(', ')}`
+          : '戦闘データ読み込み中...'}
+      </div>
+    )
+  }
+
+  const { player, enemies } = battleData
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: 16,
+        pointerEvents: 'none',
+        color: '#fff',
+        fontFamily: 'monospace',
+      }}
+    >
+      {/* 敵エリア */}
+      <div style={{ display: 'flex', gap: 16 }}>
+        {enemies.map((enemy) => (
+          <div
+            key={enemy.id}
+            style={{ background: 'rgba(0,0,0,0.6)', padding: 8, borderRadius: 4 }}
+          >
+            <div style={{ fontWeight: 'bold' }}>{enemy.name}</div>
+            <div>
+              HP: {enemy.health.current}/{enemy.health.max}
+            </div>
+            <div>ブロック: {enemy.block.value}</div>
+            {enemy.statusEffects.length > 0 && (
+              <div style={{ marginTop: 4 }}>
+                {enemy.statusEffects.map((se) => (
+                  <StatusIcon key={se.id} effect={se} />
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* プレイヤーエリア */}
+      <div
+        style={{
+          background: 'rgba(0,0,0,0.6)',
+          padding: 8,
+          borderRadius: 4,
+          alignSelf: 'flex-start',
+        }}
+      >
+        <div style={{ fontWeight: 'bold' }}>{player.name}</div>
+        <div>
+          HP: {player.health.current}/{player.health.max}
+        </div>
+        <div>ブロック: {player.block.value}</div>
+        {player.statusEffects.length > 0 && (
+          <div style={{ marginTop: 4 }}>
+            {player.statusEffects.map((se) => (
+              <StatusIcon key={se.id} effect={se} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/presentation/viewmodels/useBattleViewModel.ts
+++ b/src/presentation/viewmodels/useBattleViewModel.ts
@@ -9,6 +9,8 @@ import { type Target } from '../../shared/types'
 import { EffectFactory } from '../../application/effects/EffectFactory'
 import { executeEffects } from '../../application/effects/EffectExecutor'
 import { type BattleState } from '../../domain/entities/BattleState'
+import { tickStatusEffects } from '../../domain/rules/StatusEffectRules'
+import { notifyPlayerPowers, notifyEnemyPowers } from '../../domain/entities/Power'
 
 /**
  * 戦闘データの discriminated union
@@ -51,6 +53,14 @@ interface BattleViewModelState {
     randomService: IRandomService,
   ) => void
   readonly playCard: (card: Card, target: Target | undefined) => void
+  /** プレイヤーターン開始処理: プレイヤーの Block をリセット、Poison ダメージを適用 */
+  readonly startPlayerTurn: () => void
+  /** プレイヤーターン終了処理: プレイヤーの持続型 StatusEffect を1ターン減算 */
+  readonly endPlayerTurn: () => void
+  /** 敵ターン開始処理: 全敵の Block をリセット、敵の Poison ダメージを適用 */
+  readonly startEnemyTurn: () => void
+  /** 敵ターン終了処理: 全敵の持続型 StatusEffect を1ターン減算 */
+  readonly endEnemyTurn: () => void
 }
 
 export const useBattleViewModel = create<BattleViewModelState>()(
@@ -97,6 +107,80 @@ export const useBattleViewModel = create<BattleViewModelState>()(
           status: 'active' as const,
           player: nextState.player,
           enemies: nextState.enemies,
+          randomService: battleData.randomService,
+        })
+      })
+    },
+
+    startPlayerTurn: () => {
+      const { battleData } = get()
+      if (battleData.status !== 'active') return
+
+      const stateWithResetBlock = {
+        player: { ...battleData.player, block: battleData.player.block.reset() } as Player,
+        enemies: battleData.enemies,
+      }
+      const nextState = notifyPlayerPowers({ type: 'on_turn_start' }, stateWithResetBlock)
+
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player: nextState.player,
+          enemies: nextState.enemies,
+          randomService: battleData.randomService,
+        })
+      })
+    },
+
+    endPlayerTurn: () => {
+      const { battleData } = get()
+      if (battleData.status !== 'active') return
+
+      const tickedPlayer = tickStatusEffects(battleData.player)
+
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player: tickedPlayer,
+          enemies: battleData.enemies,
+          randomService: battleData.randomService,
+        })
+      })
+    },
+
+    startEnemyTurn: () => {
+      const { battleData } = get()
+      if (battleData.status !== 'active') return
+
+      const stateWithResetBlock = {
+        player: battleData.player,
+        enemies: battleData.enemies.map(
+          (enemy): Enemy => ({ ...enemy, block: enemy.block.reset() }),
+        ),
+      }
+      const nextState = notifyEnemyPowers({ type: 'on_turn_start' }, stateWithResetBlock)
+
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player: nextState.player,
+          enemies: nextState.enemies,
+          randomService: battleData.randomService,
+        })
+      })
+    },
+
+    endEnemyTurn: () => {
+      const { battleData } = get()
+      if (battleData.status !== 'active') return
+
+      const tickedEnemies: readonly Enemy[] = battleData.enemies.map(tickStatusEffects)
+
+      set((draft) => {
+        draft.battleData = castDraft({
+          status: 'active' as const,
+          player: battleData.player,
+          enemies: tickedEnemies,
           randomService: battleData.randomService,
         })
       })

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -32,6 +32,8 @@ export type EffectDef = {
   readonly type: string
   readonly value: number
   readonly target?: string
+  /** apply_status_effect エフェクト専用: 付与する状態効果の種別（StatusEffectType 文字列）*/
+  readonly statusEffectType?: string
 }
 
 // --- Re-exports ---

--- a/tests/application/effects/ApplyStatusEffectEffect.test.ts
+++ b/tests/application/effects/ApplyStatusEffectEffect.test.ts
@@ -1,0 +1,318 @@
+/**
+ * ApplyStatusEffectEffect テスト（RED フェーズ）
+ *
+ * 対象: src/application/effects/ApplyStatusEffectEffect.ts（未実装）
+ *       および EffectFactory への 'apply_status_effect' エントリ追加（未実装）
+ *
+ * カバー AC:
+ *   AC1 — ApplyStatusEffectEffect が敵 / プレイヤーに状態効果を付与する
+ *          EffectFactory が 'apply_status_effect' で正しく Effect を生成する（観点26/27）
+ *
+ * AC3（UI 表示）はこのファイルではテスト対象外とする。
+ * UI 層のテストは presentation/ 配下のコンポーネントテストで別途実施すること。
+ *
+ * EffectDef の型拡張について:
+ *   現時点の EffectDef には statusEffectType フィールドが存在しない。
+ *   実装時に EffectDef を拡張するか、apply_status_effect 専用の EffectDef 派生型を追加すること。
+ *   Factory テスト（観点26/27）は EffectDef 拡張後に型アサーションを除去できる。
+ */
+import { describe, it, expect } from 'vitest'
+import { ApplyStatusEffectEffect } from '../../../src/application/effects/ApplyStatusEffectEffect'
+import { EffectFactory } from '../../../src/application/effects/EffectFactory'
+import { type BattleState } from '../../../src/domain/entities/BattleState'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type StatusEffectId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+  }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makePlayer(
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+  }>,
+): Player {
+  const health = Health.create(overrides?.currentHp ?? 80, overrides?.maxHp ?? 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makeBattleState(player: Player, enemies: Enemy[]): BattleState {
+  return { player, enemies }
+}
+
+function makeServices(): { random: IRandomService } {
+  return {
+    random: {
+      next: () => 0,
+      nextInt: (min: number) => min,
+      shuffle: <T>(array: readonly T[]): readonly T[] => [...array],
+    },
+  }
+}
+
+// ─────────────────────────────────────────────
+// ApplyStatusEffectEffect — AC1: 敵への状態効果付与
+// ─────────────────────────────────────────────
+
+describe('ApplyStatusEffectEffect — AC1: 敵への状態効果付与', () => {
+  it('観点01: 正常系 — Vulnerable(amount=2) を敵に付与すると対象敵の statusEffects に Vulnerable(duration=2) が追加される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Vulnerable, 2, 'enemy')
+    const result = effect.apply(state, context, makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.id === 'jaw_worm')
+    const vulnerable = resultEnemy?.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable).toBeDefined()
+    expect(vulnerable?.duration).toBe(2)
+  })
+
+  it('観点01: 正常系 — Weak(amount=3) を敵に付与すると対象敵の statusEffects に Weak(duration=3) が追加される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Weak, 3, 'enemy')
+    const result = effect.apply(state, context, makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.id === 'jaw_worm')
+    const weak = resultEnemy?.statusEffects.find((s) => s.type === StatusEffectType.Weak)
+    expect(weak?.duration).toBe(3)
+  })
+
+  it('観点01: 正常系 — 既存 Vulnerable(duration=1) の敵に Vulnerable(amount=2) を付与すると duration=3 になる（加算）', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)],
+    })
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Vulnerable, 2, 'enemy')
+    const result = effect.apply(state, context, makeServices())
+
+    const resultEnemy = result.enemies.find((e) => e.id === 'jaw_worm')
+    const vulnerable = resultEnemy?.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable?.duration).toBe(3)
+  })
+
+  it('観点01: 正常系 — 対象外の敵の statusEffects は変化しない（単体ターゲット）', () => {
+    const player = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm')
+    const enemy2 = makeEnemy('louse')
+    const state = makeBattleState(player, [enemy1, enemy2])
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Vulnerable, 2, 'enemy')
+    const result = effect.apply(state, context, makeServices())
+
+    const resultLouse = result.enemies.find((e) => e.id === 'louse')
+    const vulnerable = resultLouse?.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────
+// ApplyStatusEffectEffect — AC1: プレイヤーへの状態効果付与
+// ─────────────────────────────────────────────
+
+describe('ApplyStatusEffectEffect — AC1: プレイヤーへの状態効果付与', () => {
+  it('観点01: 正常系 — Vulnerable(amount=2) をプレイヤーに付与すると player.statusEffects に Vulnerable(duration=2) が追加される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'player' as const } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Vulnerable, 2, 'player')
+    const result = effect.apply(state, context, makeServices())
+
+    const vulnerable = result.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable).toBeDefined()
+    expect(vulnerable?.duration).toBe(2)
+  })
+
+  it('観点01: 正常系 — Strength(amount=3) をプレイヤーに付与すると player.statusEffects に Strength(stacks=3) が追加される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'player' as const } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Strength, 3, 'player')
+    const result = effect.apply(state, context, makeServices())
+
+    const strength = result.player.statusEffects.find((s) => s.type === StatusEffectType.Strength)
+    expect(strength?.stacks).toBe(3)
+  })
+})
+
+// ─────────────────────────────────────────────
+// ApplyStatusEffectEffect — AC1: イミュータビリティ（観点11）
+// ─────────────────────────────────────────────
+
+describe('ApplyStatusEffectEffect — AC1: イミュータビリティ', () => {
+  it('観点11: apply() は元の BattleState.enemies を変更しない', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const originalEnemyEffects = state.enemies[0]?.statusEffects
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Vulnerable, 2, 'enemy')
+    effect.apply(state, context, makeServices())
+
+    expect(state.enemies[0]?.statusEffects).toBe(originalEnemyEffects)
+    expect(state.enemies[0]?.statusEffects.length).toBe(0)
+  })
+
+  it('観点11: apply() の戻り値は元の state と別のオブジェクトである', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const context = { target: { kind: 'enemy' as const, id: makeEnemyId('jaw_worm') } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Weak, 1, 'enemy')
+    const result = effect.apply(state, context, makeServices())
+
+    expect(result).not.toBe(state)
+    expect(result.enemies).not.toBe(state.enemies)
+  })
+
+  it('観点11: apply() はプレイヤー付与時に元の player.statusEffects を変更しない', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm')
+    const state = makeBattleState(player, [enemy])
+    const originalPlayerEffects = state.player.statusEffects
+    const context = { target: { kind: 'player' as const } }
+
+    const effect = new ApplyStatusEffectEffect(StatusEffectType.Strength, 2, 'player')
+    effect.apply(state, context, makeServices())
+
+    expect(state.player.statusEffects).toBe(originalPlayerEffects)
+    expect(state.player.statusEffects.length).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────
+// EffectFactory — 観点26/27: 'apply_status_effect' の正常生成・異常生成
+// ─────────────────────────────────────────────
+
+describe('EffectFactory — 観点26: apply_status_effect の正常生成', () => {
+  it('観点26: 正常生成 — type="apply_status_effect" かつ statusEffectType="Vulnerable" で ok(Effect[]) が返る', () => {
+    const result = EffectFactory.build([
+      { type: 'apply_status_effect', value: 2, target: 'enemy', statusEffectType: 'Vulnerable' },
+    ])
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.length).toBe(1)
+    }
+  })
+
+  it('観点26: 正常生成 — statusEffectType="Strength" で Strength 付与 Effect が生成される', () => {
+    const result = EffectFactory.build([
+      { type: 'apply_status_effect', value: 3, target: 'enemy', statusEffectType: 'Strength' },
+    ])
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('EffectFactory — 観点27: apply_status_effect の異常生成', () => {
+  it('観点27: 異常生成 — statusEffectType が未知の値のとき err が返る', () => {
+    const result = EffectFactory.build([
+      { type: 'apply_status_effect', value: 2, target: 'enemy', statusEffectType: 'UnknownEffect' },
+    ])
+    expect(result.ok).toBe(false)
+  })
+
+  it('観点27: 異常生成 — value が負数のとき err が返る', () => {
+    const result = EffectFactory.build([
+      { type: 'apply_status_effect', value: -1, target: 'enemy', statusEffectType: 'Vulnerable' },
+    ])
+    expect(result.ok).toBe(false)
+  })
+})

--- a/tests/domain/entities/PoisonPower.test.ts
+++ b/tests/domain/entities/PoisonPower.test.ts
@@ -1,0 +1,247 @@
+/**
+ * PoisonPower 単体テスト（RED フェーズ）
+ *
+ * 対象: src/domain/entities/powers/PoisonPower.ts（未実装）
+ *
+ * カバー AC:
+ *   AC4 — on_turn_start でスタック数分の HP ダメージを与え、スタックを 1 減算する
+ *          stacks が 0 になったら powers から自身を除去する
+ *          on_turn_end には反応しない
+ *
+ * テスト観点マッピング:
+ *   観点01 — 正常系（プレイヤー保有・敵保有）
+ *   観点02 — 境界値（stacks=1 で Poison が除去される）
+ *   観点11 — イミュータビリティ（元の BattleState を変更しない）
+ *   観点13 — 状態遷移（on_turn_end には反応しない）
+ *   観点16 — 複数条件の組み合わせ（player/enemy それぞれのケース）
+ *   観点28 — 冪等性（同一入力で同一結果）
+ */
+import { describe, it, expect } from 'vitest'
+import { PoisonPower } from '../../../src/domain/entities/powers/PoisonPower'
+import {
+  type Power,
+  type BattleStateForPower,
+  type PowerOwner,
+  notifyPlayerPowers,
+} from '../../../src/domain/entities/Power'
+import { type GameEvent } from '../../../src/domain/entities/Relic'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { type PowerId } from '../../../src/shared/types'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeHealth(current: number, max: number): Health {
+  const result = Health.create(current, max)
+  if (!result.ok) throw new Error(`Failed to create Health: ${result.error}`)
+  return result.value
+}
+
+function makeBlock(value: number): Block {
+  const result = Block.create(value)
+  if (!result.ok) throw new Error(`Failed to create Block: ${result.error}`)
+  return result.value
+}
+
+function makePoisonPower(stacks: number): Power {
+  return new PoisonPower(stacks)
+}
+
+/**
+ * プレイヤーが PoisonPower を保有する BattleStateForPower を生成する。
+ * player.powers に PoisonPower が含まれ、enemy は空のリストとなる。
+ */
+function makeStateWithPlayerPoison(
+  playerCurrentHp: number,
+  playerMaxHp: number,
+  poisonStacks: number,
+): BattleStateForPower {
+  const poison = makePoisonPower(poisonStacks)
+  return {
+    player: {
+      health: makeHealth(playerCurrentHp, playerMaxHp),
+      block: makeBlock(0),
+      powers: [poison],
+      statusEffects: [],
+    },
+    enemies: [],
+  }
+}
+
+/**
+ * 指定した enemyId を持つ敵が PoisonPower を保有する BattleStateForPower を生成する。
+ * player.powers は空のリストとなる。
+ */
+function makeStateWithEnemyPoison(
+  enemyId: string,
+  enemyCurrentHp: number,
+  enemyMaxHp: number,
+  poisonStacks: number,
+): BattleStateForPower {
+  const poison = makePoisonPower(poisonStacks)
+  return {
+    player: {
+      health: makeHealth(50, 50),
+      block: makeBlock(0),
+      powers: [],
+      statusEffects: [],
+    },
+    enemies: [
+      {
+        id: enemyId,
+        health: makeHealth(enemyCurrentHp, enemyMaxHp),
+        block: makeBlock(0),
+        powers: [poison],
+        statusEffects: [],
+      },
+    ],
+  }
+}
+
+const ON_TURN_START: GameEvent = { type: 'on_turn_start' }
+const ON_TURN_END: GameEvent = { type: 'on_turn_end' }
+
+const PLAYER_OWNER: PowerOwner = { kind: 'player' }
+
+function enemyOwner(id: string): PowerOwner {
+  return { kind: 'enemy', id }
+}
+
+// ─────────────────────────────────────────────
+// AC4: on_turn_start — プレイヤー保有ケース
+// ─────────────────────────────────────────────
+
+describe('PoisonPower — AC4: on_turn_start (プレイヤー保有)', () => {
+  it('観点01: 正常系 — プレイヤーが stacks=3 の PoisonPower を持つとき、on_turn_start で HP が 3 減り stacks が 2 になる', () => {
+    const poison = makePoisonPower(3)
+    const state = makeStateWithPlayerPoison(30, 50, 3)
+
+    const result = poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+
+    expect(result.player.health.current).toBe(27)
+
+    const updatedPoison = result.player.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(updatedPoison).toBeDefined()
+    expect(updatedPoison?.stacks).toBe(2)
+  })
+
+  it('観点02: 境界値（最小正常値）— プレイヤーが stacks=1 の PoisonPower を持つとき、on_turn_start で HP が 1 減り PoisonPower が除去される', () => {
+    const poison = makePoisonPower(1)
+    const state = makeStateWithPlayerPoison(30, 50, 1)
+
+    const result = poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+
+    expect(result.player.health.current).toBe(29)
+
+    const remainingPoison = result.player.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(remainingPoison).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: on_turn_start — 敵保有ケース
+// ─────────────────────────────────────────────
+
+describe('PoisonPower — AC4: on_turn_start (敵保有)', () => {
+  it('観点16: 複数条件の組み合わせ — 敵が stacks=4 の PoisonPower を持つとき、on_turn_start でその敵の HP が 4 減り stacks が 3 になる', () => {
+    const poison = makePoisonPower(4)
+    const state = makeStateWithEnemyPoison('jaw_worm', 40, 40, 4)
+
+    const result = poison.onTrigger(ON_TURN_START, enemyOwner('jaw_worm'), state)
+
+    const enemy = result.enemies.find((e) => e.id === 'jaw_worm')
+    expect(enemy).toBeDefined()
+    expect(enemy?.health.current).toBe(36)
+
+    const updatedPoison = enemy?.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(updatedPoison).toBeDefined()
+    expect(updatedPoison?.stacks).toBe(3)
+  })
+
+  it('観点02: 境界値（最小正常値）— 敵が stacks=1 の PoisonPower を持つとき、on_turn_start でその敵の HP が 1 減り PoisonPower が除去される', () => {
+    const poison = makePoisonPower(1)
+    const state = makeStateWithEnemyPoison('cultist', 20, 20, 1)
+
+    const result = poison.onTrigger(ON_TURN_START, enemyOwner('cultist'), state)
+
+    const enemy = result.enemies.find((e) => e.id === 'cultist')
+    expect(enemy).toBeDefined()
+    expect(enemy?.health.current).toBe(19)
+
+    const remainingPoison = enemy?.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(remainingPoison).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: on_turn_end — 反応しない
+// ─────────────────────────────────────────────
+
+describe('PoisonPower — AC4: on_turn_end には反応しない', () => {
+  it('観点13: 状態遷移 — notifyPlayerPowers で on_turn_end を送っても HP・stacks が変化しない', () => {
+    const state = makeStateWithPlayerPoison(30, 50, 3)
+
+    // onTrigger の呼び出しは notifyPlayerPowers 経由で行うのが正しい設計
+    // triggers に含まれない event.type は notifyPlayerPowers がフィルタするため Poison は発火しない
+    const result = notifyPlayerPowers(ON_TURN_END, state)
+
+    expect(result.player.health.current).toBe(30)
+
+    const remainingPoison = result.player.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(remainingPoison?.stacks).toBe(3)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: イミュータビリティ
+// ─────────────────────────────────────────────
+
+describe('PoisonPower — AC4: イミュータビリティ', () => {
+  it('観点11: 元の BattleState を変更しない（プレイヤー保有ケース）', () => {
+    const poison = makePoisonPower(3)
+    const state = makeStateWithPlayerPoison(30, 50, 3)
+
+    const originalHp = state.player.health.current
+    const originalPowers = state.player.powers
+    const originalPoisonStacks = state.player.powers[0]?.stacks
+
+    poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+
+    expect(state.player.health.current).toBe(originalHp)
+    expect(state.player.powers).toBe(originalPowers)
+    expect(state.player.powers[0]?.stacks).toBe(originalPoisonStacks)
+  })
+
+  it('観点11: 戻り値は元の state と別のオブジェクトである（プレイヤー保有ケース）', () => {
+    const poison = makePoisonPower(3)
+    const state = makeStateWithPlayerPoison(30, 50, 3)
+
+    const result = poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+
+    expect(result).not.toBe(state)
+    expect(result.player).not.toBe(state.player)
+    expect(result.player.powers).not.toBe(state.player.powers)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: 冪等性
+// ─────────────────────────────────────────────
+
+describe('PoisonPower — AC4: 冪等性', () => {
+  it('観点28: 同じ入力を2回与えると同じ結果が返る（プレイヤー保有ケース）', () => {
+    const poison = makePoisonPower(3)
+    const state = makeStateWithPlayerPoison(30, 50, 3)
+
+    const result1 = poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+    const result2 = poison.onTrigger(ON_TURN_START, PLAYER_OWNER, state)
+
+    expect(result1.player.health.current).toBe(result2.player.health.current)
+
+    const poison1 = result1.player.powers.find((p) => p.id === ('poison' as PowerId))
+    const poison2 = result2.player.powers.find((p) => p.id === ('poison' as PowerId))
+    expect(poison1?.stacks).toBe(poison2?.stacks)
+  })
+})

--- a/tests/domain/rules/StatusEffectRules.test.ts
+++ b/tests/domain/rules/StatusEffectRules.test.ts
@@ -1,0 +1,238 @@
+/**
+ * StatusEffectRules テスト（RED フェーズ）
+ *
+ * 対象: src/domain/rules/StatusEffectRules.ts（未実装）
+ *
+ * カバー AC:
+ *   AC1 — 状態効果のスタック数が正しく増減すること
+ *   AC2 — ターン終了時に継続時間が短縮・消滅する状態効果が正しく処理されること
+ *
+ * AC3（UI 表示）はこのファイルではテスト対象外とする。
+ * UI 層のテストは presentation/ 配下のコンポーネントテストで別途実施すること。
+ */
+import { describe, it, expect } from 'vitest'
+import { addStatusEffect, tickStatusEffects } from '../../../src/domain/rules/StatusEffectRules'
+import { type Combatant } from '../../../src/domain/entities/Character'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
+import { type StatusEffectId } from '../../../src/shared/types'
+
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+
+// ─────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeCombatant(statusEffects: StatusEffect[] = []): Combatant {
+  const health = Health.create(50, 50)
+  const block = Block.create(0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+  return {
+    health: health.value,
+    block: block.value,
+    powers: [],
+    statusEffects,
+  }
+}
+
+// ─────────────────────────────────────────────
+// addStatusEffect — AC1: スタック型（Strength / Dexterity / Artifact）
+// ─────────────────────────────────────────────
+
+describe('addStatusEffect — AC1: スタック型の加算', () => {
+  it('観点01: 正常系 — Strength を持たない Combatant に Strength(3) を付与すると stacks=3 の StatusEffect が追加される', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Strength, 3)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Strength)
+    expect(se).toBeDefined()
+    expect(se?.stacks).toBe(3)
+  })
+
+  it('観点01: 正常系 — 既存 Strength(2) に Strength(3) を付与すると stacks=5 になる（スタック加算）', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Strength, 2, 0)])
+    const result = addStatusEffect(combatant, StatusEffectType.Strength, 3)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Strength)
+    expect(se?.stacks).toBe(5)
+  })
+
+  it('観点02: 境界値（最小正常値）— amount=1 で正常に付与される', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Strength, 1)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Strength)
+    expect(se?.stacks).toBe(1)
+  })
+
+  it('観点02: 境界値 — amount=0 を付与しても stacks は増えない（既存がなければ追加されないか stacks=0）', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Strength, 0)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Strength)
+    expect(se?.stacks ?? 0).toBe(0)
+  })
+
+  it('観点16: 複数の異なるスタック型エフェクトが同時に存在できる', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Strength, 2, 0)])
+    const result = addStatusEffect(combatant, StatusEffectType.Dexterity, 4)
+    const strength = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Strength,
+    )
+    const dexterity = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Dexterity,
+    )
+    expect(strength?.stacks).toBe(2)
+    expect(dexterity?.stacks).toBe(4)
+  })
+})
+
+// ─────────────────────────────────────────────
+// addStatusEffect — AC1: 持続ターン型（Vulnerable / Weak）
+// ─────────────────────────────────────────────
+
+describe('addStatusEffect — AC1: 持続ターン型の加算', () => {
+  it('観点01: 正常系 — Vulnerable を持たない Combatant に Vulnerable(2) を付与すると duration=2 になる', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Vulnerable, 2)
+    const se = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(se).toBeDefined()
+    expect(se?.duration).toBe(2)
+  })
+
+  it('観点01: 正常系 — 既存 Vulnerable(duration=1) に Vulnerable(2) を付与すると duration=3 になる', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Vulnerable, 0, 1)])
+    const result = addStatusEffect(combatant, StatusEffectType.Vulnerable, 2)
+    const se = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(se?.duration).toBe(3)
+  })
+
+  it('観点01: 正常系 — Weak(3) を付与すると duration=3 になる', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Weak, 3)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Weak)
+    expect(se?.duration).toBe(3)
+  })
+})
+
+// ─────────────────────────────────────────────
+// addStatusEffect — AC1: イミュータビリティ（観点11）
+// ─────────────────────────────────────────────
+
+describe('addStatusEffect — AC1: イミュータビリティ', () => {
+  it('観点11: addStatusEffect は元の Combatant オブジェクトを変更しない', () => {
+    const original = makeCombatant([makeStatusEffect(StatusEffectType.Strength, 2, 0)])
+    const originalEffects = original.statusEffects
+    const originalStacks = original.statusEffects[0]?.stacks
+
+    addStatusEffect(original, StatusEffectType.Strength, 3)
+
+    expect(original.statusEffects).toBe(originalEffects)
+    expect(original.statusEffects[0]?.stacks).toBe(originalStacks)
+  })
+
+  it('観点11: addStatusEffect の戻り値は元の Combatant と別のオブジェクトである', () => {
+    const combatant = makeCombatant()
+    const result = addStatusEffect(combatant, StatusEffectType.Strength, 3)
+    expect(result).not.toBe(combatant)
+    expect(result.statusEffects).not.toBe(combatant.statusEffects)
+  })
+})
+
+// ─────────────────────────────────────────────
+// tickStatusEffects — AC2: 持続ターン型の減算・消滅
+// ─────────────────────────────────────────────
+
+describe('tickStatusEffects — AC2: 持続ターン型の tick', () => {
+  it('観点01: 正常系 — Vulnerable(duration=2) を tick すると duration=1 になる', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)])
+    const result = tickStatusEffects(combatant)
+    const se = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(se?.duration).toBe(1)
+  })
+
+  it('観点13: 有効遷移 — Weak(duration=1) を tick すると StatusEffect が除去される（duration が 0 になったら消滅）', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Weak, 0, 1)])
+    const result = tickStatusEffects(combatant)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Weak)
+    expect(se).toBeUndefined()
+  })
+
+  it('観点02: 境界値 — duration=0 の持続型エフェクトは tick 後も除去される', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Vulnerable, 0, 0)])
+    const result = tickStatusEffects(combatant)
+    const se = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(se).toBeUndefined()
+  })
+
+  it('観点16: 複数の持続型エフェクトがそれぞれ正しく tick される', () => {
+    const combatant = makeCombatant([
+      makeStatusEffect(StatusEffectType.Vulnerable, 0, 3),
+      makeStatusEffect(StatusEffectType.Weak, 0, 1),
+    ])
+    const result = tickStatusEffects(combatant)
+    const vulnerable = result.statusEffects.find(
+      (s: StatusEffect) => s.type === StatusEffectType.Vulnerable,
+    )
+    const weak = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Weak)
+    expect(vulnerable?.duration).toBe(2)
+    expect(weak).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────
+// tickStatusEffects — AC2: スタック型は tick で変化しない
+// ─────────────────────────────────────────────
+
+describe('tickStatusEffects — AC2: スタック型は tick で不変', () => {
+  it('観点01: Strength(stacks=3) は tickStatusEffects で stacks が変化しない', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Strength, 3, 0)])
+    const result = tickStatusEffects(combatant)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Strength)
+    expect(se?.stacks).toBe(3)
+  })
+
+  it('観点01: Dexterity(stacks=5) は tickStatusEffects で stacks が変化しない', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Dexterity, 5, 0)])
+    const result = tickStatusEffects(combatant)
+    const se = result.statusEffects.find((s: StatusEffect) => s.type === StatusEffectType.Dexterity)
+    expect(se?.stacks).toBe(5)
+  })
+})
+
+// ─────────────────────────────────────────────
+// tickStatusEffects — AC2: イミュータビリティ（観点11）
+// ─────────────────────────────────────────────
+
+describe('tickStatusEffects — AC2: イミュータビリティ', () => {
+  it('観点11: tickStatusEffects は元の Combatant を変更しない', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)])
+    const originalDuration = combatant.statusEffects[0]?.duration
+
+    tickStatusEffects(combatant)
+
+    expect(combatant.statusEffects[0]?.duration).toBe(originalDuration)
+  })
+
+  it('観点11: tickStatusEffects の戻り値は元の Combatant と別のオブジェクトである', () => {
+    const combatant = makeCombatant([makeStatusEffect(StatusEffectType.Weak, 0, 2)])
+    const result = tickStatusEffects(combatant)
+    expect(result).not.toBe(combatant)
+    expect(result.statusEffects).not.toBe(combatant.statusEffects)
+  })
+})

--- a/tests/presentation/viewmodels/useBattleViewModel.statusEffects.test.ts
+++ b/tests/presentation/viewmodels/useBattleViewModel.statusEffects.test.ts
@@ -1,0 +1,532 @@
+/**
+ * useBattleViewModel 状態効果テスト（RED フェーズ）
+ *
+ * 対象: src/presentation/viewmodels/useBattleViewModel.ts の拡張アクション（未実装）
+ *   - endPlayerTurn()   — 全コンバタントの持続型 StatusEffect を tick
+ *   - startPlayerTurn() — プレイヤーの Block をリセット、Poison ダメージを処理
+ *   - startEnemyTurn()  — 敵全員の Block をリセット、敵の Poison ダメージを処理
+ *
+ * カバー AC:
+ *   AC1 — startPlayerTurn / startEnemyTurn でスタック型エフェクトが保持される
+ *   AC2 — endPlayerTurn で Vulnerable / Weak の duration が減る
+ *   AC4 — startPlayerTurn でプレイヤーの Poison がダメージを与え stacks が 1 減る
+ *   AC5 — startPlayerTurn でプレイヤーの block が 0 になる
+ *         startEnemyTurn で敵の block が 0 になる
+ *
+ * AC3（UI 表示）はこのファイルではテスト対象外とする。
+ * UI 層のテストは presentation/ 配下のコンポーネントテストで別途実施すること。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useBattleViewModel } from '../../../src/presentation/viewmodels/useBattleViewModel'
+import { type Player } from '../../../src/domain/entities/Player'
+import { type Enemy } from '../../../src/domain/entities/Enemy'
+import { type StatusEffect, StatusEffectType } from '../../../src/domain/entities/StatusEffect'
+import { type Power } from '../../../src/domain/entities/Power'
+import { PoisonPower } from '../../../src/domain/entities/powers/PoisonPower'
+import { type IRandomService } from '../../../src/domain/interfaces/IRandomService'
+import { type EnemyId, type StatusEffectId } from '../../../src/shared/types'
+import { Health } from '../../../src/domain/value-objects/Health'
+import { Block } from '../../../src/domain/value-objects/Block'
+import { Energy } from '../../../src/domain/value-objects/Energy'
+import { Gold } from '../../../src/domain/value-objects/Gold'
+
+// ─────────────────────────────────────────────
+// Test helpers（useBattleViewModel.test.ts と同等）
+// ─────────────────────────────────────────────
+
+function makeEnemyId(id: string): EnemyId {
+  return id as EnemyId
+}
+
+function makeStatusEffect(type: StatusEffectType, stacks: number, duration: number): StatusEffect {
+  return {
+    id: `${type}_test` as StatusEffectId,
+    name: type,
+    type,
+    stacks,
+    duration,
+  }
+}
+
+function makeEnemy(
+  id: string,
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+    powers: Power[]
+  }>,
+): Enemy {
+  const hp = Health.create(overrides?.currentHp ?? 50, overrides?.maxHp ?? 50)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!hp.ok) throw new Error('Failed to create health')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id,
+    name: `Enemy_${id}`,
+    enemyId: makeEnemyId(id),
+    intent: { type: 'unknown' },
+    health: hp.value,
+    block: block.value,
+    powers: overrides?.powers ?? [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makePlayer(
+  overrides?: Partial<{
+    currentHp: number
+    maxHp: number
+    block: number
+    statusEffects: StatusEffect[]
+    powers: Power[]
+  }>,
+): Player {
+  const health = Health.create(overrides?.currentHp ?? 80, overrides?.maxHp ?? 80)
+  const energy = Energy.create(3, 3)
+  const gold = Gold.create(0)
+  const block = Block.create(overrides?.block ?? 0)
+  if (!health.ok) throw new Error('Failed to create health')
+  if (!energy.ok) throw new Error('Failed to create energy')
+  if (!gold.ok) throw new Error('Failed to create gold')
+  if (!block.ok) throw new Error('Failed to create block')
+
+  return {
+    id: 'ironclad',
+    name: 'Ironclad',
+    health: health.value,
+    energy: energy.value,
+    gold: gold.value,
+    block: block.value,
+    deck: [],
+    hand: [],
+    discardPile: [],
+    exhaustPile: [],
+    relics: [],
+    maxPotionSlots: 3,
+    potions: [null, null, null],
+    powers: overrides?.powers ?? [],
+    statusEffects: overrides?.statusEffects ?? [],
+  }
+}
+
+function makeRandomService(): IRandomService {
+  return {
+    next: vi.fn(() => 0),
+    nextInt: vi.fn((min: number) => min),
+    shuffle: vi.fn(<T>(array: readonly T[]): readonly T[] => [
+      ...array,
+    ]) as IRandomService['shuffle'],
+  }
+}
+
+// ─────────────────────────────────────────────
+// Setup
+// ─────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useBattleViewModel.setState({
+    battleData: { status: 'idle' },
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC5: startPlayerTurn — プレイヤーの Block リセット
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - startPlayerTurn: AC5 プレイヤーの block リセット', () => {
+  it('観点01: 正常系 — startPlayerTurn を呼ぶとプレイヤーの block が 0 になる', () => {
+    const player = makePlayer({ block: 10 })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.block.value).toBe(0)
+  })
+
+  it('観点02: 境界値 — block=0 のプレイヤーに startPlayerTurn を呼んでも block=0 のまま', () => {
+    const player = makePlayer({ block: 0 })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.block.value).toBe(0)
+  })
+
+  it('観点11: イミュータビリティ — startPlayerTurn は元の player オブジェクトを変更しない', () => {
+    const player = makePlayer({ block: 5 })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const originalBlock = player.block.value
+    useBattleViewModel.getState().startPlayerTurn()
+
+    expect(player.block.value).toBe(originalBlock)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC5: startEnemyTurn — 敵の Block リセット
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - startEnemyTurn: AC5 敵の block リセット', () => {
+  it('観点01: 正常系 — startEnemyTurn を呼ぶと全ての敵の block が 0 になる', () => {
+    const player = makePlayer()
+    const enemy1 = makeEnemy('jaw_worm', { block: 8 })
+    const enemy2 = makeEnemy('louse', { block: 5 })
+    useBattleViewModel.getState().initBattle(player, [enemy1, enemy2], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.enemies.find((e) => e.id === 'jaw_worm')?.block.value).toBe(0)
+    expect(battleData.enemies.find((e) => e.id === 'louse')?.block.value).toBe(0)
+  })
+
+  it('観点02: 境界値 — block=0 の敵に startEnemyTurn を呼んでも block=0 のまま', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { block: 0 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.enemies.find((e) => e.id === 'jaw_worm')?.block.value).toBe(0)
+  })
+
+  it('観点11: イミュータビリティ — startEnemyTurn は元の enemies 配列を変更しない', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { block: 6 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    const originalBlock = enemy.block.value
+    useBattleViewModel.getState().startEnemyTurn()
+
+    expect(enemy.block.value).toBe(originalBlock)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: startPlayerTurn — Poison ダメージ処理
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - startPlayerTurn: AC4 Poison ダメージ', () => {
+  it('観点01: 正常系 — プレイヤーが PoisonPower(stacks=3) を持つとき startPlayerTurn で HP が 3 減り stacks が 1 減る（stacks=2 になる）', () => {
+    const player = makePlayer({
+      currentHp: 50,
+      maxHp: 50,
+      powers: [new PoisonPower(3)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.health.current).toBe(47)
+    const poison = battleData.player.powers.find((p) => p.id === 'poison')
+    expect(poison?.stacks).toBe(2)
+  })
+
+  it('観点02: 境界値 — PoisonPower(stacks=1) のとき startPlayerTurn で HP が 1 減り、PoisonPower が除去される', () => {
+    const player = makePlayer({
+      currentHp: 50,
+      maxHp: 50,
+      powers: [new PoisonPower(1)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.health.current).toBe(49)
+    const poison = battleData.player.powers.find((p) => p.id === 'poison')
+    expect(poison).toBeUndefined()
+  })
+
+  it('観点01: 正常系 — PoisonPower を持たないプレイヤーは startPlayerTurn で HP が変化しない', () => {
+    const player = makePlayer({ currentHp: 50, maxHp: 50 })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.health.current).toBe(50)
+  })
+
+  it('観点16: 組み合わせ — PoisonPower(stacks=3) かつ block=5 のとき、block がリセットされてから Poison ダメージが HP に直接入る', () => {
+    // startPlayerTurn の処理順: (1) block を 0 にリセット → (2) Poison ダメージ（block 0 なので HP に直撃）
+    const player = makePlayer({
+      currentHp: 50,
+      maxHp: 50,
+      block: 5,
+      powers: [new PoisonPower(3)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    expect(battleData.player.block.value).toBe(0)
+    expect(battleData.player.health.current).toBe(47)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC2: endPlayerTurn — 持続ターン型 StatusEffect の tick
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - endPlayerTurn: AC2 持続ターン型 StatusEffect の tick', () => {
+  it('観点01: 正常系 — Vulnerable(duration=2) を持つプレイヤーに endPlayerTurn を呼ぶと duration=1 になる', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const vulnerable = battleData.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable?.duration).toBe(1)
+  })
+
+  it('観点13: 有効遷移 — Weak(duration=1) を持つプレイヤーに endPlayerTurn を呼ぶと Weak が消滅する', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Weak, 0, 1)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const weak = battleData.player.statusEffects.find((s) => s.type === StatusEffectType.Weak)
+    expect(weak).toBeUndefined()
+  })
+
+  it('観点01: 正常系 — Strength（スタック型）は endPlayerTurn で stacks が変化しない', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Strength, 4, 0)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const strength = battleData.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Strength,
+    )
+    expect(strength?.stacks).toBe(4)
+  })
+
+  it('観点16: 組み合わせ — endPlayerTurn はプレイヤーの Vulnerable のみ tick し、敵の Weak は変化しない', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)],
+    })
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Weak, 0, 1)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+
+    const playerVulnerable = battleData.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    const enemyWeak = battleData.enemies
+      .find((e) => e.id === 'jaw_worm')
+      ?.statusEffects.find((s) => s.type === StatusEffectType.Weak)
+
+    expect(playerVulnerable?.duration).toBe(1)
+    expect(enemyWeak?.duration).toBe(1) // 敵の Weak は endPlayerTurn では tick されない
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC2: endEnemyTurn — 敵の持続ターン型 StatusEffect の tick
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - endEnemyTurn: AC2 敵の持続ターン型 StatusEffect の tick', () => {
+  it('観点01: 正常系 — Vulnerable(duration=2) を持つ敵に endEnemyTurn を呼ぶと duration=1 になる', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    const vulnerable = resultEnemy?.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    expect(vulnerable?.duration).toBe(1)
+  })
+
+  it('観点13: 有効遷移 — Weak(duration=1) を持つ敵に endEnemyTurn を呼ぶと Weak が消滅する', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Weak, 0, 1)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    const weak = resultEnemy?.statusEffects.find((s) => s.type === StatusEffectType.Weak)
+    expect(weak).toBeUndefined()
+  })
+
+  it('観点16: 組み合わせ — endEnemyTurn は敵の Weak のみ tick し、プレイヤーの Vulnerable は変化しない', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Vulnerable, 0, 2)],
+    })
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Weak, 0, 1)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().endEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+
+    const playerVulnerable = battleData.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Vulnerable,
+    )
+    const enemyWeak = battleData.enemies
+      .find((e) => e.id === 'jaw_worm')
+      ?.statusEffects.find((s) => s.type === StatusEffectType.Weak)
+
+    expect(playerVulnerable?.duration).toBe(2) // プレイヤーの Vulnerable は endEnemyTurn では tick されない
+    expect(enemyWeak).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC4: startEnemyTurn — 敵の Poison ダメージ処理
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - startEnemyTurn: AC4 敵の Poison ダメージ', () => {
+  it('観点01: 正常系 — PoisonPower(stacks=3) を持つ敵の startEnemyTurn で HP が 3 減り stacks が 1 減る（stacks=2 になる）', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 40,
+      maxHp: 40,
+      powers: [new PoisonPower(3)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    expect(resultEnemy?.health.current).toBe(37)
+    const poison = resultEnemy?.powers.find((p) => p.id === 'poison')
+    expect(poison?.stacks).toBe(2)
+  })
+
+  it('観点02: 境界値 — PoisonPower(stacks=1) の敵の startEnemyTurn で HP が 1 減り、PoisonPower が除去される', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      currentHp: 40,
+      maxHp: 40,
+      powers: [new PoisonPower(1)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    expect(resultEnemy?.health.current).toBe(39)
+    const poison = resultEnemy?.powers.find((p) => p.id === 'poison')
+    expect(poison).toBeUndefined()
+  })
+
+  it('観点01: 正常系 — PoisonPower を持たない敵は startEnemyTurn で HP が変化しない', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', { currentHp: 40, maxHp: 40 })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    expect(resultEnemy?.health.current).toBe(40)
+  })
+})
+
+// ─────────────────────────────────────────────
+// AC1: startPlayerTurn / startEnemyTurn — スタック型は保持
+// ─────────────────────────────────────────────
+
+describe('useBattleViewModel - AC1: ターン移行でスタック型 StatusEffect が保持される', () => {
+  it('観点01: startPlayerTurn でプレイヤーの Strength(stacks=3) が変化しない', () => {
+    const player = makePlayer({
+      statusEffects: [makeStatusEffect(StatusEffectType.Strength, 3, 0)],
+    })
+    const enemy = makeEnemy('jaw_worm')
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startPlayerTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const strength = battleData.player.statusEffects.find(
+      (s) => s.type === StatusEffectType.Strength,
+    )
+    expect(strength?.stacks).toBe(3)
+  })
+
+  it('観点01: startEnemyTurn で敵の Strength(stacks=2) が変化しない', () => {
+    const player = makePlayer()
+    const enemy = makeEnemy('jaw_worm', {
+      statusEffects: [makeStatusEffect(StatusEffectType.Strength, 2, 0)],
+    })
+    useBattleViewModel.getState().initBattle(player, [enemy], makeRandomService())
+
+    useBattleViewModel.getState().startEnemyTurn()
+
+    const { battleData } = useBattleViewModel.getState()
+    if (battleData.status !== 'active') throw new Error('expected active')
+    const resultEnemy = battleData.enemies.find((e) => e.id === 'jaw_worm')
+    const strength = resultEnemy?.statusEffects.find((s) => s.type === StatusEffectType.Strength)
+    expect(strength?.stacks).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

- `StatusEffect`（受動型: Strength/Dexterity/Artifact/Vulnerable/Weak）と `Power`（能動型Observer: PoisonPower）を分離した設計を採用
- `StatusEffectRules`: `addStatusEffect` / `tickStatusEffects` 純粋関数でスタック・持続ターン管理（AC1/AC2）
- `ApplyStatusEffectEffect` + `EffectFactory`: カードプレイ時の状態効果付与エフェクト
- `Power` / `PoisonPower`: Observerパターンでターン開始時にダメージ＋スタック減算（AC4）
- `useBattleViewModel`: `startPlayerTurn` / `endPlayerTurn` / `startEnemyTurn` / `endEnemyTurn` でターンライフサイクル管理（AC5）
- `BattleScreen`: HP・ブロック・状態効果アイコンを表示（AC3）
- presentation層の domain 直接 import を解消（`StatusEffectView` ローカル型）

## Test plan

- [ ] `tests/domain/rules/StatusEffectRules.test.ts` — addStatusEffect / tickStatusEffects
- [ ] `tests/application/effects/ApplyStatusEffectEffect.test.ts` — 状態効果付与エフェクト
- [ ] `tests/domain/entities/PoisonPower.test.ts` — PoisonPower の on_turn_start 発火・イミュータビリティ
- [ ] `tests/presentation/viewmodels/useBattleViewModel.statusEffects.test.ts` — ターンライフサイクル全AC
- [ ] `npm run typecheck` / `npm run lint` / `npm run test` 全パス確認

Closes #139
Closes #39